### PR TITLE
Add central configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ storage/
 public/uploads/
 
 # credenciais locais
-config.php
+# config.php

--- a/config.php
+++ b/config.php
@@ -1,0 +1,46 @@
+<?php
+// config.php - application configuration and auth helpers
+
+session_start();
+
+$pdo = new PDO('sqlite:' . __DIR__ . '/db.sqlite');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+function currentUser()
+{
+    global $pdo;
+    if (!isset($_SESSION['user_id'])) {
+        return null;
+    }
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+    $stmt->execute([$_SESSION['user_id']]);
+    return $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+function requireLogin()
+{
+    if (!isset($_SESSION['user_id'])) {
+        header('Location: index.php');
+        exit();
+    }
+}
+
+function requireAdmin()
+{
+    requireLogin();
+    if (($_SESSION['user_role'] ?? null) !== 'admin') {
+        header('Location: index.php');
+        exit();
+    }
+}
+
+function requirePrivileged()
+{
+    requireLogin();
+    $role = $_SESSION['user_role'] ?? null;
+    if (!in_array($role, ['admin', 'manager'], true)) {
+        header('Location: index.php');
+        exit();
+    }
+}
+


### PR DESCRIPTION
## Summary
- provide `config.php` with PDO connection and auth helper functions
- stop ignoring `config.php` in git so it is available in repo

## Testing
- `php -l config.php`
- `php -l authenticate.php`
- `php -l dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a057684833283f1a8099244093e