### PR TITLE
Enforce employee auth guards via config helpers

### DIFF
--- a/employee_dashboard.php
+++ b/employee_dashboard.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'config.php';
-require_once 'authenticate.php';
+requireEmployee();
 require_once 'helpers.php';
 
 // Somente funcionários logados

--- a/employee_preferences.php
+++ b/employee_preferences.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'config.php';
-require_once 'authenticate.php';
+requireEmployee();
 require_once 'helpers.php';
 
 // Garante que apenas funcionários logados possam acessar

--- a/employee_preferences_save.php
+++ b/employee_preferences_save.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'config.php';
-require_once 'authenticate.php';
+requireEmployee();
 
 $funcionario_id = $_POST['funcionario_id'] ?? null;
 if (!$funcionario_id) {


### PR DESCRIPTION
## Summary
- remove the legacy authenticate.php include from employee-facing pages
- call requireEmployee() after loading config.php to enforce employee authentication

## Testing
- php -l employee_dashboard.php
- php -l employee_preferences.php
- php -l employee_preferences_save.php

------
https://chatgpt.com/codex/tasks/task_e_68cea6f75aa48332a71d7188c13704bb