### PR TITLE
Translate remaining Portuguese strings

### DIFF
--- a/authenticate.php
+++ b/authenticate.php
@@ -32,6 +32,6 @@ if ($user && password_verify($password, $user['password'])) {
 }
 
 // If we reach here, login failed
-$_SESSION['login_error'] = 'Usuário ou senha inválidos.';
+$_SESSION['login_error'] = 'Invalid username or password.';
 header('Location: index.php');
 exit();

--- a/config.example.php
+++ b/config.example.php
@@ -10,7 +10,7 @@ if (session_status() === PHP_SESSION_NONE) {
     ]);
     session_start();
 }
-// Notificações (opcionais)
+// Notifications (optional)
 $MAIL_FROM       = getenv('MAIL_FROM') ?: 'no-reply@localhost';
 $MAIL_FROM_NAME  = getenv('MAIL_FROM_NAME') ?: 'Escala Hillbillys';
 $SLACK_WEBHOOK   = getenv('SLACK_WEBHOOK_URL') ?: '';
@@ -71,10 +71,10 @@ function requireRole(array $roles): void {
     $role = $u['role'] ?? null;
     if (!$role || !in_array($role, $roles, true)) {
         http_response_code(403);
-        die('Acesso negado.');
+        die('Access denied.');
     }
 }
-// --- Compat Shims (código legado) ---
+// --- Compat Shims (legacy code) ---
 function requireAdmin(): void {
     // Ensure user is logged in and has admin role
     requireLogin();
@@ -91,8 +91,8 @@ function requireEmployee(): void {
     requireRole(['employee']);
 }
 /**
- * Em versões antigas, "privileged" normalmente significava "admin ou manager".
- * Ajuste se o seu conceito for diferente.
+ * In older versions, "privileged" usually meant "admin or manager".
+ * Adjust if your definition differs.
  */
 function requirePrivileged(): void {
     // Ensure user is logged in and has admin or manager role
@@ -100,7 +100,7 @@ function requirePrivileged(): void {
     requireRole(['admin','manager']);
 }
 
-/** Helpers legados comuns */
+/** Common legacy helpers */
 function isAdmin(): bool {
     $u = currentUser();
     return ($u['role'] ?? null) === 'admin';

--- a/create_shift.php
+++ b/create_shift.php
@@ -1,10 +1,10 @@
 <?php
 // create_shift_restricted.php
-// Script para criar turnos com validações adicionais: datas passadas e restrição por loja.
-// Requer funções utilitárias definidas em config.php: assertNotPastDate, userCanManageStore, getEmployeeStoreId.
+// Script to create shifts with additional validation: past-date checks and per-store restrictions.
+// Requires utility functions defined in config.php: assertNotPastDate, userCanManageStore, getEmployeeStoreId.
 
 require_once 'config.php';
-// Inclua notificações se estiver usando o sistema de avisos
+// Include notifications if the alert system is enabled
 @require_once 'notifications_helpers.php';
 
 requirePrivileged();
@@ -14,57 +14,57 @@ $storeId = $user['store_id'] ?? null;
 
 header('Content-Type: application/json');
 
-// Obter parâmetros
+// Retrieve parameters
 $employeeId = isset($_POST['employee_id']) ? (int)$_POST['employee_id'] : 0;
 $date       = trim($_POST['date'] ?? '');
 $startTime  = trim($_POST['start_time'] ?? '');
 $endTime    = trim($_POST['end_time'] ?? '');
 
 if (!$employeeId || !$date || !$startTime || !$endTime) {
-    echo json_encode(['success' => false, 'message' => 'Parâmetros incompletos.']);
+    echo json_encode(['success' => false, 'message' => 'Incomplete parameters.']);
     exit();
 }
 
 try {
-    // Bloquear criação em datas passadas
+    // Prevent creation for past dates
     assertNotPastDate($date);
 
-    // Buscar loja do funcionário
+    // Fetch the employee's store
     $empStoreId = getEmployeeStoreId($pdo, $employeeId);
     if ($empStoreId === null) {
-        echo json_encode(['success' => false, 'message' => 'Funcionário não encontrado.']);
+        echo json_encode(['success' => false, 'message' => 'Employee not found.']);
         exit();
     }
-    // Restrição de gerentes à própria loja
+    // Restrict managers to their store
     if (!userCanManageStore($empStoreId)) {
-        echo json_encode(['success' => false, 'message' => 'Você não tem permissão para atribuir turnos a este funcionário.']);
+        echo json_encode(['success' => false, 'message' => 'You do not have permission to assign shifts to this employee.']);
         exit();
     }
-    // Verificar duplicidade de turno na mesma data
+    // Ensure no duplicate shift on the same date
     $dupStmt = $pdo->prepare('SELECT COUNT(*) FROM shifts WHERE employee_id = ? AND date = ?');
     $dupStmt->execute([$employeeId, $date]);
     if ($dupStmt->fetchColumn() > 0) {
-        echo json_encode(['success' => false, 'message' => 'Já existe um turno para este funcionário nesta data.']);
+        echo json_encode(['success' => false, 'message' => 'A shift already exists for this employee on that date.']);
         exit();
     }
-    // Verificar preferências de disponibilidade (se existir tabela employee_preferences)
+    // Check availability preferences (if table exists)
     $dow = date('w', strtotime($date));
     $prefStmt = $pdo->prepare('SELECT available_start_time, available_end_time FROM employee_preferences WHERE employee_id = ? AND day_of_week = ?');
     $prefStmt->execute([$employeeId, $dow]);
     if ($pref = $prefStmt->fetch(PDO::FETCH_ASSOC)) {
         if (strcmp($startTime, $pref['available_start_time']) < 0 || strcmp($endTime, $pref['available_end_time']) > 0) {
-            echo json_encode(['success' => false, 'message' => 'Horário fora da preferência deste funcionário.']);
+            echo json_encode(['success' => false, 'message' => 'Shift time is outside this employee’s preferred window.']);
             exit();
         }
     }
-    // Verificar limite de horas semanais, se a coluna existir
+    // Check weekly hour limit, if defined
     $empStmt = $pdo->prepare('SELECT max_weekly_hours, name FROM employees WHERE id = ?');
     $empStmt->execute([$employeeId]);
     $emp = $empStmt->fetch(PDO::FETCH_ASSOC);
     $maxWeekly = $emp['max_weekly_hours'] ?? null;
     if ($maxWeekly) {
         $duration = (strtotime($date . ' ' . $endTime) - strtotime($date . ' ' . $startTime)) / 3600.0;
-        // Calcular horas já agendadas na semana
+        // Calculate already scheduled hours for the week
         $timestamp = strtotime($date);
         $monday = date('Y-m-d', strtotime('monday this week', $timestamp));
         $sunday = date('Y-m-d', strtotime('sunday this week', $timestamp));
@@ -75,18 +75,18 @@ try {
             $currentHours += max(0, (strtotime($sh['date'].' '.$sh['end_time']) - strtotime($sh['date'].' '.$sh['start_time'])) / 3600.0);
         }
         if ($currentHours + $duration > (float)$maxWeekly) {
-            echo json_encode(['success' => false, 'message' => 'Atribuição excede o limite de horas semanais deste funcionário ('.$maxWeekly.'h).']);
+            echo json_encode(['success' => false, 'message' => 'Assignment exceeds this employee’s weekly hour limit ('.$maxWeekly.'h).']);
             exit();
         }
     }
-    // Inserir turno
+    // Insert shift
     $ins = $pdo->prepare('INSERT INTO shifts (employee_id, date, start_time, end_time) VALUES (?, ?, ?, ?)');
     $ins->execute([$employeeId, $date, $startTime, $endTime]);
     $shiftId = $pdo->lastInsertId();
-    // Notificar
+    // Notification
     if (function_exists('addNotification')) {
         $storeName = $pdo->query('SELECT name FROM stores WHERE id = '.$empStoreId)->fetchColumn();
-        $msg = formatShiftMsg($date, $startTime, $endTime, $storeName, 'Turno atribuído');
+        $msg = formatShiftMsg($date, $startTime, $endTime, $storeName, 'Shift assigned');
         addNotification($pdo, $employeeId, $msg, 'shift_created');
     }
     echo json_encode(['success' => true, 'shift' => [
@@ -97,5 +97,5 @@ try {
         'end_time' => $endTime
     ]]);
 } catch (Exception $e) {
-    echo json_encode(['success' => false, 'message' => 'Erro: '.$e->getMessage()]);
+    echo json_encode(['success' => false, 'message' => 'Error: '.$e->getMessage()]);
 }

--- a/dashboard.php
+++ b/dashboard.php
@@ -31,11 +31,11 @@ for ($i = 6; $i >= 0; $i--) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Painel – Escala Hillbillys</title>
+    <title>Dashboard – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -53,34 +53,34 @@ for ($i = 6; $i >= 0; $i--) {
         <div class="row mb-4">
             <div class="col-md-4">
                 <div class="card text-white bg-success mb-3">
-                    <div class="card-header">Funcionários</div>
+                    <div class="card-header">Employees</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $employeeCount; ?></h5>
-                        <p class="card-text">Número de funcionários cadastrados.</p>
+                        <p class="card-text">Number of employees registered.</p>
                     </div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card text-white bg-info mb-3">
-                    <div class="card-header">Escalas Futuras</div>
+                    <div class="card-header">Upcoming Shifts</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $shiftsCount; ?></h5>
-                        <p class="card-text">Número de turnos agendados.</p>
+                        <p class="card-text">Number of scheduled shifts.</p>
                     </div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card text-white bg-warning mb-3">
-                    <div class="card-header">Horas no Mês</div>
+                    <div class="card-header">Hours This Month</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $totalHours; ?> h</h5>
-                        <p class="card-text">Horas trabalhadas no mês atual.</p>
+                        <p class="card-text">Hours worked in the current month.</p>
                     </div>
                 </div>
             </div>
         </div>
         <div class="card">
-            <div class="card-header">Horas trabalhadas (últimos 7 dias)</div>
+            <div class="card-header">Hours Worked (Last 7 Days)</div>
             <div class="card-body">
                 <canvas id="hoursChart"></canvas>
             </div>
@@ -98,7 +98,7 @@ for ($i = 6; $i >= 0; $i--) {
         data: {
             labels: chartLabels,
             datasets: [{
-                label: 'Horas trabalhadas',
+                label: 'Hours worked',
                 data: chartData,
                 backgroundColor: 'rgba(54, 162, 235, 0.5)',
                 borderColor: 'rgba(54, 162, 235, 1)',
@@ -109,10 +109,10 @@ for ($i = 6; $i >= 0; $i--) {
             scales: {
                 y: {
                     beginAtZero: true,
-                    title: { display: true, text: 'Horas' }
+                    title: { display: true, text: 'Hours' }
                 },
                 x: {
-                    title: { display: true, text: 'Data' }
+                    title: { display: true, text: 'Date' }
                 }
             },
             plugins: {

--- a/delete_shift.php
+++ b/delete_shift.php
@@ -5,13 +5,13 @@ requirePrivileged();
 header('Content-Type: application/json');
 $user=currentUser(); $role=$user['role']; $storeId=$user['store_id']??null;
 $shiftId=$_POST['id']??null;
-if(!$shiftId){ echo json_encode(['success'=>false,'message'=>'ID do turno não fornecido.']); exit(); }
+if(!$shiftId){ echo json_encode(['success'=>false,'message'=>'Shift ID not provided.']); exit(); }
 try{
   $stmtShift=$pdo->prepare('SELECT s.id,s.employee_id,s.date,s.start_time,s.end_time,e.name AS employee_name,e.store_id,st.name AS store_name FROM shifts s JOIN employees e ON s.employee_id=e.id LEFT JOIN stores st ON st.id=e.store_id WHERE s.id=?');
   $stmtShift->execute([$shiftId]); $shift=$stmtShift->fetch(PDO::FETCH_ASSOC);
-  if(!$shift){ echo json_encode(['success'=>false,'message'=>'Turno não encontrado.']); exit(); }
-  if($role==='manager' && $storeId!==null && (int)$shift['store_id']!==(int)$storeId){ echo json_encode(['success'=>false,'message'=>'Você não tem permissão para excluir este turno.']); exit(); }
+  if(!$shift){ echo json_encode(['success'=>false,'message'=>'Shift not found.']); exit(); }
+  if($role==='manager' && $storeId!==null && (int)$shift['store_id']!==(int)$storeId){ echo json_encode(['success'=>false,'message'=>'You do not have permission to delete this shift.']); exit(); }
   $pdo->prepare('DELETE FROM shifts WHERE id=?')->execute([$shiftId]);
-  $msg=formatShiftMsg($shift['date'],$shift['start_time'],$shift['end_time'],$shift['store_name']??null,'Turno cancelado'); addNotification($pdo,(int)$shift['employee_id'],$msg,'shift_deleted');
+  $msg=formatShiftMsg($shift['date'],$shift['start_time'],$shift['end_time'],$shift['store_name']??null,'Shift cancelled'); addNotification($pdo,(int)$shift['employee_id'],$msg,'shift_deleted');
   echo json_encode(['success'=>true]);
-}catch(Exception $e){ echo json_encode(['success'=>false,'message'=>'Erro: '.$e->getMessage()]); }
+}catch(Exception $e){ echo json_encode(['success'=>false,'message'=>'Error: '.$e->getMessage()]); }

--- a/desempenho.php
+++ b/desempenho.php
@@ -1,10 +1,10 @@
 <?php
-// desempenho.php – relatório de desempenho de funcionários
+// desempenho.php – employee performance report
 require_once 'config.php';
 // Only allow managers and admins to view performance reports
 requirePrivileged();
 
-// Determine metrics: total hours, number of entries, number of completed entries, number of late entries (with justification), average duration
+// Determine metrics: total hours, number of entries, completed entries, late entries (with justification), and average duration
 $role = $_SESSION['user_role'];
 if ($role === 'manager') {
     $user = currentUser();
@@ -45,33 +45,33 @@ foreach ($metrics as &$row) {
 unset($row);
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Desempenho – Escala Hillbillys</title>
+    <title>Performance – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <?php
-        // Definir página ativa para desempenho
+        // Set the active navbar page for performance
         $activePage = 'desempenho';
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
         <div class="d-flex justify-content-between align-items-center mb-3">
-            <h3>Desempenho de Funcionários</h3>
-            <a href="export_performance.php" class="btn btn-secondary">Exportar CSV</a>
+            <h3>Employee Performance</h3>
+            <a href="export_performance.php" class="btn btn-secondary">Export CSV</a>
         </div>
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th>Funcionário</th>
-                    <th>Horas Totais</th>
-                    <th>Total de Registros</th>
-                    <th>Entradas Completadas</th>
-                    <th>Registros com Justificativa</th>
+                    <th>Employee</th>
+                    <th>Total Hours</th>
+                    <th>Total Entries</th>
+                    <th>Completed Entries</th>
+                    <th>Entries with Justification</th>
                 </tr>
             </thead>
             <tbody>
@@ -85,7 +85,7 @@ unset($row);
                     </tr>
                 <?php endforeach; ?>
                 <?php if (empty($metrics)): ?>
-                    <tr><td colspan="5">Nenhum dado disponível.</td></tr>
+                    <tr><td colspan="5">No data available.</td></tr>
                 <?php endif; ?>
             </tbody>
         </table>

--- a/employee_dashboard.php
+++ b/employee_dashboard.php
@@ -3,14 +3,14 @@ require_once 'config.php';
 requireEmployee();
 require_once 'helpers.php';
 
-// Somente funcionários logados
+// Ensure only logged-in employees reach this page
 $funcionario_id = $_SESSION['user_id'] ?? null;
 if (!$funcionario_id) {
     header('Location: index.php');
     exit;
 }
 
-// Calcula início e fim da semana corrente (segunda a domingo) considerando fuso Europe/Dublin
+// Calculate the current week's start and end (Monday to Sunday) using the Europe/Dublin timezone
 $tz       = new DateTimeZone('Europe/Dublin');
 $now      = new DateTime('now', $tz);
 $weekStart = clone $now;
@@ -29,18 +29,18 @@ $earnings      = $hoursWorked * $rate;
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Painel do Funcionário</title>
+    <title>Employee Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUa4y3Yz2+1Jqv1MDwse4bCMZJ6uaOYJ6xZgTwHUnYlXyt1e1NEMqH9cO2+" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <?php include 'navbar.php'; ?>
 <div class="container mt-4">
-    <h1>Meu Painel</h1>
+    <h1>My Dashboard</h1>
     <div class="row">
         <div class="col-md-4 mb-3">
             <div class="card shadow-sm">
-                <div class="card-header">Horas Trabalhadas (semana)</div>
+                <div class="card-header">Hours Worked (week)</div>
                 <div class="card-body">
                     <h3 class="card-title"><?php echo number_format($hoursWorked, 2); ?> h</h3>
                 </div>
@@ -48,7 +48,7 @@ $earnings      = $hoursWorked * $rate;
         </div>
         <div class="col-md-4 mb-3">
             <div class="card shadow-sm">
-                <div class="card-header">Horas Restantes</div>
+                <div class="card-header">Hours Remaining</div>
                 <div class="card-body">
                     <h3 class="card-title"><?php echo number_format($hoursRemaining, 2); ?> h</h3>
                 </div>
@@ -56,14 +56,14 @@ $earnings      = $hoursWorked * $rate;
         </div>
         <div class="col-md-4 mb-3">
             <div class="card shadow-sm">
-                <div class="card-header">Ganhos Estimados</div>
+                <div class="card-header">Estimated Earnings</div>
                 <div class="card-body">
                     <h3 class="card-title">€<?php echo number_format($earnings, 2); ?></h3>
                 </div>
             </div>
         </div>
     </div>
-    <a href="employee_preferences.php" class="btn btn-secondary mt-4">Editar Preferências</a>
+    <a href="employee_preferences.php" class="btn btn-secondary mt-4">Edit Preferences</a>
 </div>
 </body>
 </html>

--- a/employee_preferences.php
+++ b/employee_preferences.php
@@ -3,14 +3,14 @@ require_once 'config.php';
 requireEmployee();
 require_once 'helpers.php';
 
-// Garante que apenas funcionários logados possam acessar
+// Ensure only logged-in employees can access
 $funcionario_id = $_SESSION['user_id'] ?? null;
 if (!$funcionario_id) {
     header('Location: index.php');
     exit;
 }
 
-// Recupera preferências existentes
+// Retrieve existing preferences
 $stmt = $conn->prepare('SELECT day_of_week, available_start, available_end, max_hours_per_day, min_rest_hours FROM employee_preferences WHERE funcionario_id = ?');
 $stmt->bind_param('i', $funcionario_id);
 $stmt->execute();
@@ -21,7 +21,7 @@ while ($row = $result->fetch_assoc()) {
 }
 $stmt->close();
 
-// Funções auxiliares para valores padrão
+// Helper for default values
 function get_pref_field($prefs, $day, $field) {
     return isset($prefs[$day][$field]) ? $prefs[$day][$field] : '';
 }
@@ -31,29 +31,29 @@ function get_pref_field($prefs, $day, $field) {
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Preferências de Funcionário</title>
+    <title>Employee Preferences</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUa4y3Yz2+1Jqv1MDwse4bCMZJ6uaOYJ6xZgTwHUnYlXyt1e1NEMqH9cO2+" crossorigin="anonymous">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <?php include 'navbar.php'; ?>
 <div class="container mt-4">
-    <h1>Minhas Preferências de Turno</h1>
+    <h1>My Shift Preferences</h1>
     <form action="employee_preferences_save.php" method="post">
         <input type="hidden" name="funcionario_id" value="<?php echo htmlspecialchars($funcionario_id); ?>">
         <table class="table table-bordered">
             <thead>
                 <tr>
-                    <th>Dia da Semana</th>
-                    <th>Início Disponível</th>
-                    <th>Fim Disponível</th>
-                    <th>Máx Horas/Dia</th>
-                    <th>Descanso Mín. (h)</th>
+                    <th>Day of Week</th>
+                    <th>Available Start</th>
+                    <th>Available End</th>
+                    <th>Max Hours/Day</th>
+                    <th>Minimum Rest (h)</th>
                 </tr>
             </thead>
             <tbody>
                 <?php
-                $dias = ['Domingo','Segunda','Terça','Quarta','Quinta','Sexta','Sábado'];
+                $dias = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
                 for ($d = 0; $d < 7; $d++):
                     $pref = $preferences[$d] ?? [];
                 ?>
@@ -68,14 +68,14 @@ function get_pref_field($prefs, $day, $field) {
             </tbody>
         </table>
         <div class="mb-3">
-            <label for="weekly_max_hours" class="form-label">Horas Máximas por Semana:</label>
+            <label for="weekly_max_hours" class="form-label">Maximum Hours per Week:</label>
             <input type="number" step="0.5" name="weekly_max_hours" id="weekly_max_hours" value="<?php echo htmlspecialchars(getWeeklyMaxHours($funcionario_id, $conn)); ?>" class="form-control" required>
         </div>
         <div class="mb-3">
-            <label for="hourly_rate" class="form-label">Salário por Hora (€):</label>
+            <label for="hourly_rate" class="form-label">Hourly Rate (€):</label>
             <input type="number" step="0.01" name="hourly_rate" id="hourly_rate" value="<?php echo htmlspecialchars(getHourlyRate($funcionario_id, $conn)); ?>" class="form-control" required>
         </div>
-        <button type="submit" class="btn btn-primary">Salvar Preferências</button>
+        <button type="submit" class="btn btn-primary">Save Preferences</button>
     </form>
 </div>
 </body>

--- a/employee_preferences_save.php
+++ b/employee_preferences_save.php
@@ -8,7 +8,7 @@ if (!$funcionario_id) {
     exit;
 }
 
-// Atualiza limites semanais e salário por hora
+// Update weekly limits and hourly rate
 $weekly_max_hours = isset($_POST['weekly_max_hours']) ? floatval($_POST['weekly_max_hours']) : 40;
 $hourly_rate      = isset($_POST['hourly_rate'])      ? floatval($_POST['hourly_rate'])      : 0;
 $stmt = $conn->prepare('UPDATE funcionarios SET weekly_max_hours = ?, hourly_rate = ? WHERE id = ?');
@@ -16,7 +16,7 @@ $stmt->bind_param('ddi', $weekly_max_hours, $hourly_rate, $funcionario_id);
 $stmt->execute();
 $stmt->close();
 
-// Preferências por dia
+// Daily preferences
 $preferences = $_POST['preferences'] ?? [];
 for ($d = 0; $d < 7; $d++) {
     $pref = $preferences[$d] ?? [];
@@ -27,14 +27,14 @@ for ($d = 0; $d < 7; $d++) {
 
     $isEmpty = empty($available_start) && empty($available_end) && empty($max_hours) && empty($min_rest);
     if ($isEmpty) {
-        // Remove preferência existente
+        // Remove existing preference
         $del = $conn->prepare('DELETE FROM employee_preferences WHERE funcionario_id = ? AND day_of_week = ?');
         $del->bind_param('ii', $funcionario_id, $d);
         $del->execute();
         $del->close();
         continue;
     }
-    // Insere ou atualiza
+    // Insert or update preference
     $sql = 'INSERT INTO employee_preferences (funcionario_id, day_of_week, available_start, available_end, max_hours_per_day, min_rest_hours) VALUES (?,?,?,?,?,?) '
          . 'ON DUPLICATE KEY UPDATE available_start=VALUES(available_start), available_end=VALUES(available_end), max_hours_per_day=VALUES(max_hours_per_day), min_rest_hours=VALUES(min_rest_hours)';
     $ins = $conn->prepare($sql);

--- a/escala_calendario.php
+++ b/escala_calendario.php
@@ -1,5 +1,5 @@
 <?php
-// Versão aprimorada do calendário interativo com correção de sobreposição da tela cinza após salvar
+// Enhanced interactive calendar with corrected backdrop overlap after saving
 require_once 'config.php';
 requireLogin();
 $user = currentUser();
@@ -39,10 +39,10 @@ try {
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Calendário Interativo – Escala Hillbillys</title>
+    <title>Interactive Calendar – Escala Hillbillys</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
@@ -55,36 +55,36 @@ try {
     require_once __DIR__ . '/navbar.php';
 ?>
 <div class="container">
-  <h3 class="mb-3">Calendário Interativo</h3>
+  <h3 class="mb-3">Interactive Calendar</h3>
   <div id="calendar"></div>
 </div>
-<!-- Modal de turno-->
+<!-- Shift modal -->
 <div class="modal fade" id="shiftModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Turno</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        <h5 class="modal-title">Shift</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <form id="shiftForm">
           <input type="hidden" id="shift-id" name="shift_id" />
           <div class="mb-3">
-            <label class="form-label">Data</label>
+            <label class="form-label">Date</label>
             <input type="date" id="shift-date" name="date" class="form-control" readonly required>
           </div>
           <div class="mb-3">
-            <label class="form-label">Horário de início</label>
+            <label class="form-label">Start time</label>
             <input type="time" id="shift-start" name="start_time" class="form-control" required>
           </div>
           <div class="mb-3">
-            <label class="form-label">Horário de término</label>
+            <label class="form-label">End time</label>
             <input type="time" id="shift-end" name="end_time" class="form-control" required>
           </div>
           <div class="mb-3">
-            <label class="form-label">Funcionário</label>
+            <label class="form-label">Employee</label>
             <select id="shift-employee" name="employee_id" class="form-select" required>
-              <option value="">Selecione…</option>
+              <option value="">Select…</option>
               <?php foreach ($employeesList as $emp): ?>
                 <option value="<?php echo $emp['id']; ?>"><?php echo htmlspecialchars($emp['name']); ?></option>
               <?php endforeach; ?>
@@ -93,26 +93,26 @@ try {
         </form>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
-        <button type="button" class="btn btn-primary" id="save-btn">Salvar</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary" id="save-btn">Save</button>
       </div>
     </div>
   </div>
 </div>
-<!-- Modal de exclusão-->
+<!-- Delete modal -->
 <div class="modal fade" id="deleteModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Confirmar Exclusão</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
+        <h5 class="modal-title">Confirm Deletion</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <p id="delete-info"></p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-        <button type="button" class="btn btn-danger" id="delete-btn">Excluir</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="delete-btn">Delete</button>
       </div>
     </div>
   </div>
@@ -143,14 +143,14 @@ async function submitShift(calendar) {
     const res = await fetch(url, { method:'POST', body: fd });
     const data = await res.json();
     if (!data.success) {
-      alert(data.message || 'Erro ao salvar.');
+      alert(data.message || 'Error saving.');
     }
-    // Em qualquer caso (sucesso ou erro) feche o modal e limpe backdrop
+    // Regardless of success or failure, close the modal and clear the backdrop
     bootstrap.Modal.getInstance(document.getElementById('shiftModal')).hide();
     clearBackdrops();
     calendar.refetchEvents();
   } catch (e) {
-    alert('Falha na comunicação.');
+    alert('Communication failed.');
     bootstrap.Modal.getInstance(document.getElementById('shiftModal')).hide();
     clearBackdrops();
   }
@@ -161,12 +161,12 @@ async function removeShift(calendar, shiftId) {
   try {
     const res = await fetch('delete_shift.php', { method:'POST', body: fd });
     const data = await res.json();
-    if (!data.success) alert(data.message || 'Erro ao excluir.');
+    if (!data.success) alert(data.message || 'Error deleting.');
     bootstrap.Modal.getInstance(document.getElementById('deleteModal')).hide();
     clearBackdrops();
     calendar.refetchEvents();
   } catch (e) {
-    alert('Falha na comunicação.');
+    alert('Communication failed.');
     bootstrap.Modal.getInstance(document.getElementById('deleteModal')).hide();
     clearBackdrops();
   }
@@ -176,7 +176,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
     headerToolbar: { left:'prev,next today', center:'title', right:'dayGridMonth,timeGridWeek,timeGridDay' },
-    locale: 'pt-br',
+    locale: 'en-gb',
     selectable: <?php echo ($user['role'] === 'admin' || $user['role'] === 'manager') ? 'true' : 'false'; ?>,
     editable: <?php echo ($user['role'] === 'admin' || $user['role'] === 'manager') ? 'true' : 'false'; ?>,
     events: <?php echo json_encode($events, JSON_UNESCAPED_UNICODE); ?>,
@@ -211,7 +211,7 @@ document.addEventListener('DOMContentLoaded', function() {
       if (ev.extendedProps && ev.extendedProps.employee_id) {
         document.getElementById('shift-employee').value = ev.extendedProps.employee_id;
       }
-      // configurar exclusão
+      // configure deletion
       document.getElementById('delete-info').textContent = `${ev.title} - ${ev.start.toLocaleString()}`;
       document.getElementById('delete-btn').onclick = function() { removeShift(calendar, ev.id); };
       new bootstrap.Modal(document.getElementById('deleteModal')).show();
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const res = await fetch('update_shift.php', { method:'POST', body: fd });
         const data = await res.json();
         if (!data.success) {
-          alert(data.message || 'Erro ao mover turno');
+          alert(data.message || 'Error moving shift');
           info.revert();
         }
       })();
@@ -249,7 +249,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const res = await fetch('update_shift.php', { method:'POST', body: fd });
         const data = await res.json();
         if (!data.success) {
-          alert(data.message || 'Erro ao redimensionar turno');
+          alert(data.message || 'Error resizing shift');
           info.revert();
         }
       })();

--- a/escala_calendario_semana.php
+++ b/escala_calendario_semana.php
@@ -1,14 +1,14 @@
 <?php
 // escala_calendario_semana.php
-// Visualização de escalas em formato semanal. Exibe cada dia da semana corrente (ou de uma semana
-// selecionada via parâmetro) com os turnos listados em cartões. Fornece uma experiência mais
-// moderna e intuitiva em relação ao calendário interativo mensal, permitindo ao usuário
-// visualizar rapidamente quem está escalado em cada dia. Administradores veem todas as lojas;
-// gerentes veem apenas os turnos da sua loja.
+// Weekly shift visualization. Displays each day of the current week (or a selected week
+// via parameter) with shifts listed in cards. Provides a more modern and intuitive
+// experience compared to the monthly interactive calendar, letting users quickly
+// see who is scheduled each day. Administrators see every store; managers only see
+// shifts for their store.
 
 require_once 'config.php';
 
-// Verifica login e restringe acesso apenas a administradores ou gerentes
+// Verify login and restrict access to administrators or managers
 requireLogin();
 $currentUser = currentUser();
 if (!$currentUser || !in_array($currentUser['role'], ['admin','manager'])) {
@@ -16,15 +16,15 @@ if (!$currentUser || !in_array($currentUser['role'], ['admin','manager'])) {
     exit();
 }
 
-// Determina a semana a ser exibida. Aceita parâmetro GET 'week' no formato YYYY-MM-DD
-// representando qualquer dia da semana desejada. Se não houver, usa a data atual.
+// Determine which week to display. Accepts GET parameter 'week' in YYYY-MM-DD format
+// representing any day in the desired week. Defaults to today when absent.
 $weekParam = isset($_GET['week']) ? $_GET['week'] : date('Y-m-d');
 try {
     $refDate = new DateTime($weekParam);
 } catch (Exception $e) {
     $refDate = new DateTime();
 }
-// Ajusta para a segunda-feira da semana de referência (ISO 8601: Monday = 1)
+// Adjust to Monday of the reference week (ISO 8601: Monday = 1)
 $dayOfWeek = (int)$refDate->format('N');
 $monday     = clone $refDate;
 $monday->modify('-' . ($dayOfWeek - 1) . ' days');
@@ -33,7 +33,7 @@ $sunday->modify('+6 days');
 $dateStart  = $monday->format('Y-m-d');
 $dateEnd    = $sunday->format('Y-m-d');
 
-// Recupera turnos da semana conforme o papel do usuário
+// Fetch shifts for the week according to the user role
 $storeId = $currentUser['store_id'] ?? null;
 $events  = [];
 try {
@@ -57,7 +57,7 @@ try {
     $events = [];
 }
 
-// Organiza turnos por dia
+// Group shifts by day
 $shiftsByDay = [];
 for ($i = 0; $i < 7; $i++) {
     $date = clone $monday;
@@ -69,18 +69,18 @@ foreach ($events as $ev) {
     $shiftsByDay[$ev['date']][] = $ev;
 }
 
-// Função auxiliar para formatar data no padrão "Dia, DD de Mês"
+// Helper to format dates as "Day, DD Month"
 function formatDateLabel($dateStr) {
     $dt = DateTime::createFromFormat('Y-m-d', $dateStr);
-    $dias  = ['Domingo','Segunda','Terça','Quarta','Quinta','Sexta','Sábado'];
-    $meses = ['janeiro','fevereiro','março','abril','maio','junho','julho','agosto','setembro','outubro','novembro','dezembro'];
-    $diaSemana = $dias[(int)$dt->format('w')];
-    $dia       = $dt->format('d');
-    $mes       = $meses[(int)$dt->format('n') - 1];
-    return "$diaSemana, $dia de $mes";
+    $days   = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    $months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+    $dayName = $days[(int)$dt->format('w')];
+    $day     = $dt->format('d');
+    $month   = $months[(int)$dt->format('n') - 1];
+    return "$dayName, $day $month";
 }
 
-// Calcula links para semana anterior e próxima semana
+// Calculate links for previous and next weeks
 $prevWeekDate = clone $monday;
 $prevWeekDate->modify('-7 days');
 $nextWeekDate = clone $monday;
@@ -89,11 +89,11 @@ $prevWeekParam = $prevWeekDate->format('Y-m-d');
 $nextWeekParam = $nextWeekDate->format('Y-m-d');
 
 ?><!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Escalas Semanais – Escala Hillbillys</title>
+    <title>Weekly Shifts – Escala Hillbillys</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
     <style>
@@ -103,16 +103,16 @@ $nextWeekParam = $nextWeekDate->format('Y-m-d');
 </head>
 <body>
 <?php
-    // Define a página ativa como "calendario" para que o item Calendário seja destacado no menu
+    // Highlight the calendar item in the navbar
     $activePage = 'calendario';
     require_once __DIR__ . '/navbar.php';
 ?>
 <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <h3>Escalas – Semana de <?php echo htmlspecialchars($monday->format('d/m/Y')); ?> a <?php echo htmlspecialchars($sunday->format('d/m/Y')); ?></h3>
+        <h3>Shifts – Week of <?php echo htmlspecialchars($monday->format('d/m/Y')); ?> to <?php echo htmlspecialchars($sunday->format('d/m/Y')); ?></h3>
         <div>
-            <a href="?week=<?php echo urlencode($prevWeekParam); ?>" class="btn btn-outline-primary btn-sm me-2">&laquo; Semana Anterior</a>
-            <a href="?week=<?php echo urlencode($nextWeekParam); ?>" class="btn btn-outline-primary btn-sm">Próxima Semana &raquo;</a>
+            <a href="?week=<?php echo urlencode($prevWeekParam); ?>" class="btn btn-outline-primary btn-sm me-2">&laquo; Previous Week</a>
+            <a href="?week=<?php echo urlencode($nextWeekParam); ?>" class="btn btn-outline-primary btn-sm">Next Week &raquo;</a>
         </div>
     </div>
     <div class="row g-3">
@@ -124,7 +124,7 @@ $nextWeekParam = $nextWeekDate->format('Y-m-d');
                 </div>
                 <div class="card-body">
                     <?php if (empty($shifts)): ?>
-                        <p class="text-muted">Sem turnos</p>
+                        <p class="text-muted">No shifts</p>
                     <?php else: ?>
                         <ul class="list-unstyled">
                             <?php foreach ($shifts as $sh): ?>
@@ -132,9 +132,9 @@ $nextWeekParam = $nextWeekDate->format('Y-m-d');
                                 <strong><?php echo htmlspecialchars($sh['start_time']); ?>–<?php echo htmlspecialchars($sh['end_time']); ?></strong><br>
                                 <span><?php echo htmlspecialchars($sh['employee_name']); ?></span><br>
                                 <small>
-                                    <a href="escala_editar.php?id=<?php echo urlencode($sh['id']); ?>" class="text-decoration-none">Editar</a>
+                                    <a href="escala_editar.php?id=<?php echo urlencode($sh['id']); ?>" class="text-decoration-none">Edit</a>
                                     |
-                                    <a href="escala_excluir.php?id=<?php echo urlencode($sh['id']); ?>" class="text-danger text-decoration-none" onclick="return confirm('Excluir este turno?');">Excluir</a>
+                                    <a href="escala_excluir.php?id=<?php echo urlencode($sh['id']); ?>" class="text-danger text-decoration-none" onclick="return confirm('Delete this shift?');">Delete</a>
                                 </small>
                             </li>
                             <?php endforeach; ?>
@@ -146,8 +146,8 @@ $nextWeekParam = $nextWeekDate->format('Y-m-d');
         <?php endforeach; ?>
     </div>
     <div class="mt-4">
-        <a href="escala_criar.php" class="btn btn-success">Novo Turno</a>
-        <a href="escala_calendario.php" class="btn btn-outline-secondary ms-2">Ver Calendário Interativo</a>
+        <a href="escala_criar.php" class="btn btn-success">New Shift</a>
+        <a href="escala_calendario.php" class="btn btn-outline-secondary ms-2">View Interactive Calendar</a>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/escala_listar.php
+++ b/escala_listar.php
@@ -1,7 +1,7 @@
 <?php
 // escala_listar_future.php
-// Lista de escalas (turnos) futuras. Mostra apenas as escalas com data igual ou posterior à data atual.
-// Administradores veem todas as lojas; gerentes veem apenas sua loja.
+// List upcoming shifts. Shows only shifts dated today or later.
+// Administrators see every store; managers are limited to their store.
 
 require_once 'config.php';
 requirePrivileged();
@@ -9,7 +9,7 @@ $currentUser = currentUser();
 $role = $currentUser['role'];
 $storeId = $currentUser['store_id'] ?? null;
 
-// Obter escalas futuras
+// Fetch upcoming shifts
 if ($role === 'manager' && $storeId) {
     $stmt = $pdo->prepare('SELECT s.id, s.date, s.start_time, s.end_time, e.name AS employee_name
                            FROM shifts s
@@ -27,7 +27,7 @@ if ($role === 'manager' && $storeId) {
     $shifts = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-// Buscar solicitações de troca pendentes (futuras apenas)
+// Fetch pending swap requests (upcoming only)
 if ($role === 'manager' && $storeId) {
     $swapStmt = $pdo->prepare('SELECT sr.id, sr.shift_id, sr.status, e1.name AS requester, e2.name AS requested_to
                                FROM swap_requests sr
@@ -50,11 +50,11 @@ if ($role === 'manager' && $storeId) {
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Escalas Futuras – Escala Hillbillys</title>
+    <title>Upcoming Shifts – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
@@ -65,25 +65,25 @@ if ($role === 'manager' && $storeId) {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Escalas Futuras</h3>
+        <h3>Upcoming Shifts</h3>
         <div class="d-flex mb-3">
-            <a href="export_shifts.php" class="btn btn-secondary me-2">Exportar CSV</a>
-            <a href="escala_criar.php" class="btn btn-success me-2">Nova Escala</a>
-            <a href="escala_criar.php?auto=1" class="btn btn-warning me-2">Gerar Automaticamente</a>
-            <a href="escala_sugestao.php" class="btn btn-info">Sugestão IA</a>
+            <a href="export_shifts.php" class="btn btn-secondary me-2">Export CSV</a>
+            <a href="escala_criar.php" class="btn btn-success me-2">New Shift</a>
+            <a href="escala_criar.php?auto=1" class="btn btn-warning me-2">Generate Automatically</a>
+            <a href="escala_sugestao.php" class="btn btn-info">AI Suggestion</a>
         </div>
-        <!-- Solicitações de troca -->
-        <h5>Solicitações de Troca:</h5>
+        <!-- Swap requests -->
+        <h5>Swap Requests:</h5>
         <?php if (empty($swapRequests)): ?>
-            <p>Nenhuma solicitação pendente.</p>
+            <p>No pending requests.</p>
         <?php else: ?>
             <ul class="list-group mb-4">
                 <?php foreach ($swapRequests as $sr): ?>
                     <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <?php echo htmlspecialchars($sr['requester']) . ' deseja trocar com ' . htmlspecialchars($sr['requested_to']); ?>
+                        <?php echo htmlspecialchars($sr['requester']) . ' wants to swap with ' . htmlspecialchars($sr['requested_to']); ?>
                         <div>
-                            <a href="swap_action.php?id=<?php echo urlencode($sr['id']); ?>&action=approve" class="btn btn-sm btn-success ms-2">Aprovar</a>
-                            <a href="swap_action.php?id=<?php echo urlencode($sr['id']); ?>&action=reject" class="btn btn-sm btn-danger ms-1">Rejeitar</a>
+                            <a href="swap_action.php?id=<?php echo urlencode($sr['id']); ?>&action=approve" class="btn btn-sm btn-success ms-2">Approve</a>
+                            <a href="swap_action.php?id=<?php echo urlencode($sr['id']); ?>&action=reject" class="btn btn-sm btn-danger ms-1">Reject</a>
                         </div>
                     </li>
                 <?php endforeach; ?>
@@ -95,11 +95,11 @@ if ($role === 'manager' && $storeId) {
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Data</th>
-                        <th>Início</th>
-                        <th>Término</th>
-                        <th>Funcionário</th>
-                        <th>Ações</th>
+                        <th>Date</th>
+                        <th>Start</th>
+                        <th>End</th>
+                        <th>Employee</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -111,9 +111,9 @@ if ($role === 'manager' && $storeId) {
                             <td><?php echo htmlspecialchars($shift['end_time']); ?></td>
                             <td><?php echo htmlspecialchars($shift['employee_name']); ?></td>
                             <td>
-                                <a href="escala_editar.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-primary">Editar</a>
-                                <a href="escala_excluir.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-danger" onclick="return confirm('Excluir esta escala?');">Excluir</a>
-                                <a href="escala_trocar.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-warning">Troca</a>
+                                <a href="escala_editar.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-primary">Edit</a>
+                                <a href="escala_excluir.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this shift?');">Delete</a>
+                                <a href="escala_trocar.php?id=<?php echo urlencode($shift['id']); ?>" class="btn btn-sm btn-warning">Swap</a>
                             </td>
                         </tr>
                     <?php endforeach; ?>
@@ -127,7 +127,7 @@ if ($role === 'manager' && $storeId) {
     <script>
         $(document).ready(function() {
             $('#shiftsTable').DataTable({
-                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json' },
+                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json' },
                 order: [[1, 'asc'], [2, 'asc']]
             });
         });

--- a/examples/header.php
+++ b/examples/header.php
@@ -3,8 +3,8 @@
 ?>
 <nav>
   <a href="dashboard.php">Dashboard</a> |
-  <a href="loja_gerenciar_updated.php">Gerenciar Loja</a> |
-  <a href="employees_list.php">Funcionários</a> |
-  <a href="shifts_list.php">Escala</a>
+  <a href="loja_gerenciar_updated.php">Manage Store</a> |
+  <a href="employees_list.php">Employees</a> |
+  <a href="shifts_list.php">Schedule</a>
 </nav>
 <hr/>

--- a/export_employees.php
+++ b/export_employees.php
@@ -1,5 +1,5 @@
 <?php
-// export_employees.php – exportar lista de funcionários como CSV
+// export_employees.php – export the employee list as CSV
 require_once 'config.php';
 requireAdmin();
 
@@ -7,10 +7,10 @@ $stmt = $pdo->query('SELECT id, name, email, phone, created_at FROM employees OR
 $employees = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 header('Content-Type: text/csv; charset=utf-8');
-header('Content-Disposition: attachment; filename="funcionarios.csv"');
+header('Content-Disposition: attachment; filename="employees.csv"');
 $output = fopen('php://output', 'w');
 // CSV headers
-fputcsv($output, ['ID', 'Nome', 'Email', 'Telefone', 'Criado em']);
+fputcsv($output, ['ID', 'Name', 'Email', 'Phone', 'Created at']);
 foreach ($employees as $emp) {
     fputcsv($output, $emp);
 }

--- a/export_performance.php
+++ b/export_performance.php
@@ -1,5 +1,5 @@
 <?php
-// export_performance.php – exporta relatório de desempenho em CSV
+// export_performance.php – export performance report as CSV
 require_once 'config.php';
 requirePrivileged();
 
@@ -40,7 +40,7 @@ header('Content-Type: text/csv');
 header('Content-Disposition: attachment; filename="performance.csv"');
 $output = fopen('php://output', 'w');
 // Header row
-fputcsv($output, ['Funcionário', 'Horas Totais', 'Total de Registros', 'Entradas Completadas', 'Registros com Justificativa']);
+fputcsv($output, ['Employee', 'Total Hours', 'Total Entries', 'Completed Entries', 'Entries with Justification']);
 foreach ($data as $row) {
     $hours = round(($row['seconds_worked'] ?? 0) / 3600, 2);
     fputcsv($output, [

--- a/export_shifts.php
+++ b/export_shifts.php
@@ -1,5 +1,5 @@
 <?php
-// export_shifts.php – exportar escalas como CSV
+// export_shifts.php – export shift schedules as CSV
 require_once 'config.php';
 requireAdmin();
 
@@ -9,10 +9,10 @@ $stmt = $pdo->query('SELECT s.id, s.date, s.start_time, s.end_time, e.name AS em
 $shifts = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 header('Content-Type: text/csv; charset=utf-8');
-header('Content-Disposition: attachment; filename="escalas.csv"');
+header('Content-Disposition: attachment; filename="shifts.csv"');
 $output = fopen('php://output', 'w');
 // CSV headers
-fputcsv($output, ['ID', 'Data', 'Início', 'Término', 'Funcionário', 'Criado em']);
+fputcsv($output, ['ID', 'Date', 'Start', 'End', 'Employee', 'Created at']);
 foreach ($shifts as $shift) {
     fputcsv($output, $shift);
 }

--- a/export_time_entries.php
+++ b/export_time_entries.php
@@ -1,5 +1,5 @@
 <?php
-// export_time_entries.php – exportar registros de ponto como CSV
+// export_time_entries.php – export time entry records as CSV
 require_once 'config.php';
 requireAdmin();
 
@@ -10,9 +10,9 @@ $stmt = $pdo->query('SELECT te.id, e.name AS employee_name, te.clock_in, te.cloc
 $entries = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 header('Content-Type: text/csv; charset=utf-8');
-header('Content-Disposition: attachment; filename="pontos.csv"');
+header('Content-Disposition: attachment; filename="time_entries.csv"');
 $output = fopen('php://output', 'w');
-fputcsv($output, ['ID', 'Funcionário', 'Entrada', 'Saída', 'Justificativa', 'Criado em']);
+fputcsv($output, ['ID', 'Employee', 'Clock In', 'Clock Out', 'Justification', 'Created at']);
 foreach ($entries as $entry) {
     fputcsv($output, $entry);
 }

--- a/funcionario_vincular.php
+++ b/funcionario_vincular.php
@@ -1,5 +1,5 @@
 <?php
-// funcionario_vincular.php – associar funcionário a uma escala existente
+// funcionario_vincular.php – associate an employee with an existing shift
 require_once 'config.php';
 requireLogin();
 
@@ -13,17 +13,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $employee_id = (int)$_POST['employee_id'];
     $stmt = $pdo->prepare('UPDATE shifts SET employee_id = ? WHERE id = ?');
     $stmt->execute([$employee_id, $shift_id]);
-    $message = 'Funcionário vinculado com sucesso à escala.';
+    $message = 'Employee successfully assigned to the shift.';
     // Refresh shift list after update
     $shifts = $pdo->query('SELECT * FROM shifts ORDER BY date, start_time')->fetchAll(PDO::FETCH_ASSOC);
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Vincular Funcionário – Escala Hillbillys</title>
+    <title>Assign Employee – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -33,15 +33,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Vincular Funcionário a Escala</h3>
+        <h3>Assign Employee to Shift</h3>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
         <form method="post">
             <div class="mb-3">
-                <label class="form-label">Escala</label>
+                <label class="form-label">Shift</label>
                 <select class="form-select" name="shift_id" required>
-                    <option value="">Selecione uma escala</option>
+                    <option value="">Select a shift</option>
                     <?php foreach ($shifts as $shift): ?>
                         <?php $label = $shift['date'] . ' ' . $shift['start_time'] . '–' . $shift['end_time']; ?>
                         <option value="<?php echo $shift['id']; ?>" <?php if (isset($_POST['shift_id']) && $_POST['shift_id'] == $shift['id']) echo 'selected'; ?>>
@@ -51,9 +51,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </select>
             </div>
             <div class="mb-3">
-                <label class="form-label">Funcionário</label>
+                <label class="form-label">Employee</label>
                 <select class="form-select" name="employee_id" required>
-                    <option value="">Selecione um funcionário</option>
+                    <option value="">Select an employee</option>
                     <?php foreach ($employees as $emp): ?>
                         <option value="<?php echo $emp['id']; ?>" <?php if (isset($_POST['employee_id']) && $_POST['employee_id'] == $emp['id']) echo 'selected'; ?>>
                             <?php echo htmlspecialchars($emp['name']); ?>
@@ -61,8 +61,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <?php endforeach; ?>
                 </select>
             </div>
-            <button type="submit" class="btn btn-primary">Vincular</button>
-            <a href="escala_listar.php" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-primary">Assign</button>
+            <a href="escala_listar.php" class="btn btn-secondary">Cancel</a>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/funcionarios_gerenciar.php
+++ b/funcionarios_gerenciar.php
@@ -1,5 +1,5 @@
 <?php
-// funcionarios_gerenciar.php – redireciona para a listagem de funcionários.
+// funcionarios_gerenciar.php – redirect to the employee listing page.
 require_once 'config.php';
 requireLogin();
 header('Location: usuarios_listar.php');

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@ $loginError = $_SESSION['login_error'] ?? null;
 unset($_SESSION['login_error']);
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -52,14 +52,14 @@ unset($_SESSION['login_error']);
         <?php endif; ?>
         <form action="authenticate.php" method="post">
             <div class="mb-3">
-                <label for="username" class="form-label">Usuário</label>
+                <label for="username" class="form-label">Username</label>
                 <input type="text" class="form-control" id="username" name="username" required>
             </div>
             <div class="mb-3">
-                <label for="password" class="form-label">Senha</label>
+                <label for="password" class="form-label">Password</label>
                 <input type="password" class="form-control" id="password" name="password" required>
             </div>
-            <button type="submit" class="btn btn-primary w-100">Entrar</button>
+            <button type="submit" class="btn btn-primary w-100">Sign In</button>
         </form>
     </div>
     <!-- Bootstrap JS (optional) -->

--- a/init_meta3.php
+++ b/init_meta3.php
@@ -1,7 +1,7 @@
 <?php
-// Script simples para criar/alterar tabelas necessárias para a Meta 3.
-// Execute este script manualmente (por linha de comando) uma vez para
-// inicializar as colunas e tabelas adicionais.
+// Simple script to create/update tables required for Meta 3.
+// Run this script manually (via command line) once to
+// initialize the additional columns and tables.
 
 require_once 'config.php';
 
@@ -25,9 +25,9 @@ foreach ($sqls as $sql) {
     try {
         $conn->query($sql);
     } catch (Exception $e) {
-        // Ignora erros caso as colunas/tabela já existam
+        // Ignore errors if the columns/table already exist
         // echo $e->getMessage();
     }
 }
 
-echo "Meta 3: colunas e tabela configuradas.";
+echo "Meta 3: columns and table configured.";

--- a/loja_gerenciar.php
+++ b/loja_gerenciar.php
@@ -1,33 +1,33 @@
 <?php
-// loja_gerenciar.php – permite que gerentes (e administradores) visualizem e atualizem informações da loja.
-// Gerentes podem editar apenas a própria loja; administradores poderiam, em uma versão estendida,
-// selecionar qual loja editar.  Também listamos os funcionários vinculados à loja.
+// loja_gerenciar.php – allow managers (and administrators) to view and update store information.
+// Managers may edit only their store; administrators could, in an extended version,
+// select which store to edit. Employees linked to the store are also listed.
 
 require_once 'config.php';
 requirePrivileged();
 
 $role = $_SESSION['user_role'];
 $currentUser = currentUser();
-// Determinar a loja atual
+// Determine the current store
 if ($role === 'manager') {
     $storeId = $currentUser['store_id'] ?? null;
 } else {
-    // Administradores podem escolher a loja via GET; se não fornecer, usar primeira loja
+    // Administrators may choose the store via GET; otherwise use the first store
     $storeId = isset($_GET['store_id']) ? (int)$_GET['store_id'] : null;
     if (!$storeId) {
         $storeId = $pdo->query('SELECT id FROM stores ORDER BY id LIMIT 1')->fetchColumn();
     }
 }
 
-// Carregar dados da loja
+// Load store data
 $stmtStore = $pdo->prepare('SELECT * FROM stores WHERE id = ?');
 $stmtStore->execute([$storeId]);
 $store = $stmtStore->fetch(PDO::FETCH_ASSOC);
 if (!$store) {
-    die('Loja não encontrada.');
+    die('Store not found.');
 }
 
-// Processar atualização de dados da loja
+// Process store updates
 $message = null;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name = trim($_POST['name'] ?? '');
@@ -35,27 +35,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($name !== '') {
         $stmtUpd = $pdo->prepare('UPDATE stores SET name = ?, location = ? WHERE id = ?');
         $stmtUpd->execute([$name, $location, $storeId]);
-        $message = 'Dados da loja atualizados com sucesso.';
+        $message = 'Store details updated successfully.';
         // Recarregar dados da loja
         $stmtStore->execute([$storeId]);
         $store = $stmtStore->fetch(PDO::FETCH_ASSOC);
     }
 }
 
-// Buscar funcionários da loja
+// Fetch store employees
 $stmtEmp = $pdo->prepare('SELECT id, name, email, phone FROM employees WHERE store_id = ? ORDER BY name');
 $stmtEmp->execute([$storeId]);
 $employees = $stmtEmp->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Gerenciar Loja – Escala Hillbillys</title>
+    <title>Manage Store – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
-    <!-- DataTables CSS para tabela de funcionários -->
+    <!-- DataTables CSS for the employees table -->
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
 </head>
 <body>
@@ -67,49 +67,49 @@ $employees = $stmtEmp->fetchAll(PDO::FETCH_ASSOC);
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="usuarios_listar.php">Funcionários</a></li>
-                    <li class="nav-item"><a class="nav-link" href="escala_listar.php">Escalas</a></li>
-                    <li class="nav-item"><a class="nav-link" href="ponto_listar.php">Pontos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="relatorios.php">Relatórios</a></li>
-                    <li class="nav-item"><a class="nav-link" href="desempenho.php">Desempenho</a></li>
-                    <li class="nav-item"><a class="nav-link active" href="analytics.php">Métricas</a>
-                    <li class="nav-item"><a class="nav-link active" aria-current="page" href="loja_gerenciar.php">Loja</a></li>
+                    <li class="nav-item"><a class="nav-link" href="usuarios_listar.php">Employees</a></li>
+                    <li class="nav-item"><a class="nav-link" href="escala_listar.php">Schedules</a></li>
+                    <li class="nav-item"><a class="nav-link" href="ponto_listar.php">Time Entries</a></li>
+                    <li class="nav-item"><a class="nav-link" href="relatorios.php">Reports</a></li>
+                    <li class="nav-item"><a class="nav-link" href="desempenho.php">Performance</a></li>
+                    <li class="nav-item"><a class="nav-link active" href="analytics.php">Analytics</a></li>
+                    <li class="nav-item"><a class="nav-link active" aria-current="page" href="loja_gerenciar.php">Store</a></li>
                 </ul>
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link" href="logout.php">Sair</a></li>
+                    <li class="nav-item"><a class="nav-link" href="logout.php">Sign Out</a></li>
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container mt-4">
-        <h3>Gerenciar Loja</h3>
+        <h3>Manage Store</h3>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
         <form method="post" class="mb-4">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label class="form-label">Nome da Loja</label>
+                    <label class="form-label">Store Name</label>
                     <input type="text" class="form-control" name="name" value="<?php echo htmlspecialchars($store['name']); ?>" required>
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label">Localização</label>
+                    <label class="form-label">Location</label>
                     <input type="text" class="form-control" name="location" value="<?php echo htmlspecialchars($store['location']); ?>">
                 </div>
                 <div class="col-md-4 d-flex align-items-end">
-                    <button type="submit" class="btn btn-primary">Salvar</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
                 </div>
             </div>
         </form>
-        <h4>Funcionários da Loja</h4>
+        <h4>Store Employees</h4>
         <div class="table-responsive">
             <table id="employeesTable" class="table table-striped">
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Nome</th>
-                        <th>E-mail</th>
-                        <th>Telefone</th>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Phone</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -131,7 +131,7 @@ $employees = $stmtEmp->fetchAll(PDO::FETCH_ASSOC);
     <script>
     document.addEventListener('DOMContentLoaded', function () {
         $('#employeesTable').DataTable({
-            language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json' },
+            language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json' },
             order: [[1, 'asc']]
         });
     });

--- a/loja_gerenciar_updated.php
+++ b/loja_gerenciar_updated.php
@@ -1,118 +1,118 @@
 <?php
 // loja_gerenciar_updated.php
-// Página para gerenciar uma loja específica (editar nome/locação e listar funcionários).
-// Aceita parâmetro GET 'store_id' para selecionar a loja. Apenas administradores e
-// gerentes da loja podem acessar. Administradores podem gerenciar qualquer loja.
+// Page to manage a specific store (edit name/location and list employees).
+// Accepts GET parameter 'store_id' to select the store. Only administrators and
+// store managers may access. Administrators can manage any store.
 
 require_once 'config.php';
 
-// Verificar login e permissões
+// Validate login and permissions
 requirePrivileged();
 $currentUser = currentUser();
 $userRole = $currentUser['role'];
 $userStoreId = $currentUser['store_id'] ?? null;
 
-// Obter ID da loja a ser gerenciada
+// Determine which store will be managed
 $storeId = null;
 if (isset($_GET['store_id'])) {
     $storeId = (int)$_GET['store_id'];
 } elseif ($userRole === 'manager' && $userStoreId) {
-    // Gerente assume a própria loja se não informar param
+    // Manager defaults to their own store when parameter is missing
     $storeId = (int)$userStoreId;
 } else {
-    // Admin sem parâmetro: carregar a primeira loja
+    // Admin without parameter: load the first store
     $storeId = (int)$pdo->query('SELECT id FROM stores ORDER BY id LIMIT 1')->fetchColumn();
 }
 
-// Carregar dados da loja
+// Load store data
 $stmtStore = $pdo->prepare('SELECT * FROM stores WHERE id = ?');
 $stmtStore->execute([$storeId]);
 $store = $stmtStore->fetch(PDO::FETCH_ASSOC);
 if (!$store) {
-    die('Loja não encontrada.');
+    die('Store not found.');
 }
 
-// Verificar se usuário pode gerenciar esta loja: gerentes só podem gerenciar sua loja
+// Ensure the user can manage this store: managers are limited to their store
 if ($userRole === 'manager' && $userStoreId !== $storeId) {
-    die('Você não tem permissão para gerenciar esta loja.');
+    die('You do not have permission to manage this store.');
 }
 
-// Processar atualização de dados da loja (somente admin)
+// Process store updates (admins only)
 $message = null;
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_store'])) {
-    // Apenas admins podem editar loja
+    // Only admins may edit store details
     if ($userRole !== 'admin') {
-        die('Apenas administradores podem editar lojas.');
+        die('Only administrators can edit stores.');
     }
     $name = trim($_POST['name'] ?? '');
     $location = trim($_POST['location'] ?? '');
     if ($name !== '') {
         $stmtUpd = $pdo->prepare('UPDATE stores SET name = ?, location = ? WHERE id = ?');
         $stmtUpd->execute([$name, $location, $storeId]);
-        $message = 'Dados da loja atualizados com sucesso.';
+        $message = 'Store details updated successfully.';
         // Recarregar
         $stmtStore->execute([$storeId]);
         $store = $stmtStore->fetch(PDO::FETCH_ASSOC);
     }
 }
 
-// Buscar funcionários desta loja
+// Fetch employees for this store
 $stmtEmp = $pdo->prepare('SELECT id, name, email, phone FROM employees WHERE store_id = ? ORDER BY name');
 $stmtEmp->execute([$storeId]);
 $employees = $stmtEmp->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Loja – Escala Hillbillys</title>
+    <title>Manage Store – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body>
     <?php
-        // página loja/gerenciar
+        // store management page
         $activePage = ($userRole === 'admin') ? 'lojas' : 'loja';
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Gerenciar Loja</h3>
+        <h3>Manage Store</h3>
         <?php if ($message): ?>
             <div class="alert alert-success">
                 <?php echo htmlspecialchars($message); ?>
             </div>
         <?php endif; ?>
         <form method="post" class="card mb-4">
-            <div class="card-header bg-secondary text-white">Dados da Loja</div>
+            <div class="card-header bg-secondary text-white">Store Details</div>
             <div class="card-body row g-3">
                 <input type="hidden" name="update_store" value="1">
                 <div class="col-md-6">
-                    <label for="name" class="form-label">Nome</label>
+                    <label for="name" class="form-label">Name</label>
                     <input type="text" class="form-control" id="name" name="name" value="<?php echo htmlspecialchars($store['name']); ?>" required <?php echo ($userRole !== 'admin') ? 'readonly' : ''; ?>>
                 </div>
                 <div class="col-md-6">
-                    <label for="location" class="form-label">Localização</label>
+                    <label for="location" class="form-label">Location</label>
                     <input type="text" class="form-control" id="location" name="location" value="<?php echo htmlspecialchars($store['location']); ?>" <?php echo ($userRole !== 'admin') ? 'readonly' : ''; ?>>
                 </div>
                 <?php if ($userRole === 'admin'): ?>
                 <div class="col-md-12">
-                    <button type="submit" class="btn btn-primary">Salvar</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
                 </div>
                 <?php endif; ?>
             </div>
         </form>
-        <h4>Funcionários da Loja</h4>
+        <h4>Store Employees</h4>
         <div class="table-responsive">
             <table id="employeesTable" class="table table-striped">
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Nome</th>
+                        <th>Name</th>
                         <th>Email</th>
-                        <th>Telefone</th>
+                        <th>Phone</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -134,7 +134,7 @@ $employees = $stmtEmp->fetchAll(PDO::FETCH_ASSOC);
     <script>
         $(document).ready(function() {
             $('#employeesTable').DataTable({
-                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json' },
+                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json' },
                 order: [[1, 'asc']]
             });
         });

--- a/lojas_listar.php
+++ b/lojas_listar.php
@@ -1,37 +1,36 @@
 <?php
 // lojas_listar.php
-// Página para listar e criar novas lojas
-// Esta página está acessível apenas para administradores. Ela permite
-// visualizar todas as lojas cadastradas, adicionar uma nova loja e
-// acessar a página de gerenciamento de cada loja individualmente.
+// Page for listing and creating stores
+// Accessible only to administrators. Allows viewing all stores, adding
+// a new store, and navigating to each store's management page.
 
 require_once 'config.php';
 
-// Garantir que somente administradores possam acessar
+// Restrict access to administrators only
 requireAdmin();
 
-// Conectar ao banco de dados
+// Ensure database connection
 $pdo = $pdo ?? null;
 if (!$pdo) {
-    // Se por alguma razão $pdo não estiver definido em config.php, crie uma nova conexão
+    // If $pdo is not defined in config.php, create a new connection
     $dsn = 'sqlite:' . __DIR__ . '/db.sqlite';
     $pdo = new PDO($dsn);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 }
 
-// Mensagem de retorno para feedback
+// Feedback message
 $message = null;
 
-// Processar criação de nova loja
+// Handle new store creation
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_store'])) {
     $name = trim($_POST['name'] ?? '');
     $location = trim($_POST['location'] ?? '');
     if ($name === '') {
-        $message = 'O nome da loja é obrigatório.';
+        $message = 'Store name is required.';
     } else {
         $stmtInsert = $pdo->prepare('INSERT INTO stores (name, location) VALUES (?, ?)');
         $stmtInsert->execute([$name, $location]);
-        $message = 'Loja criada com sucesso.';
+        $message = 'Store created successfully.';
     }
 }
 
@@ -41,58 +40,58 @@ $stores = $stmtStores->fetchAll(PDO::FETCH_ASSOC);
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lojas – Escala Hillbillys</title>
+    <title>Stores – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
 </head>
 <body>
-    <!-- Barra de navegação -->
+    <!-- Navigation bar -->
     <?php
         $activePage = 'lojas';
         require_once __DIR__ . '/navbar.php';
     ?>
 
     <div class="container mt-4">
-        <h3>Lojas</h3>
+        <h3>Stores</h3>
         <?php if ($message): ?>
             <div class="alert alert-info">
                 <?php echo htmlspecialchars($message); ?>
             </div>
         <?php endif; ?>
-        <!-- Formulário para criar nova loja -->
+        <!-- Form to create a new store -->
         <div class="card mb-4">
-            <div class="card-header bg-secondary text-white">Adicionar Nova Loja</div>
+            <div class="card-header bg-secondary text-white">Add New Store</div>
             <div class="card-body">
                 <form method="post" class="row g-3">
                     <input type="hidden" name="create_store" value="1">
                     <div class="col-md-5">
-                        <label for="storeName" class="form-label">Nome da Loja</label>
+                        <label for="storeName" class="form-label">Store Name</label>
                         <input type="text" class="form-control" id="storeName" name="name" required>
                     </div>
                     <div class="col-md-5">
-                        <label for="storeLocation" class="form-label">Localização</label>
-                        <input type="text" class="form-control" id="storeLocation" name="location" placeholder="Opcional">
+                        <label for="storeLocation" class="form-label">Location</label>
+                        <input type="text" class="form-control" id="storeLocation" name="location" placeholder="Optional">
                     </div>
                     <div class="col-md-2 d-flex align-items-end">
-                        <button type="submit" class="btn btn-success w-100">Adicionar</button>
+                        <button type="submit" class="btn btn-success w-100">Add</button>
                     </div>
                 </form>
             </div>
         </div>
-        <!-- Tabela de lojas -->
+        <!-- Stores table -->
         <div class="table-responsive">
             <table id="storesTable" class="table table-striped">
                 <thead>
                     <tr>
                         <th>ID</th>
-                        <th>Nome</th>
-                        <th>Localização</th>
-                        <th>Ações</th>
+                        <th>Name</th>
+                        <th>Location</th>
+                        <th>Actions</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -102,7 +101,7 @@ $stores = $stmtStores->fetchAll(PDO::FETCH_ASSOC);
                             <td><?php echo htmlspecialchars($st['name']); ?></td>
                             <td><?php echo htmlspecialchars($st['location']); ?></td>
                             <td>
-                                <a href="loja_gerenciar.php?store_id=<?php echo urlencode($st['id']); ?>" class="btn btn-sm btn-primary">Editar</a>
+                                <a href="loja_gerenciar.php?store_id=<?php echo urlencode($st['id']); ?>" class="btn btn-sm btn-primary">Edit</a>
                             </td>
                         </tr>
                     <?php endforeach; ?>
@@ -117,7 +116,7 @@ $stores = $stmtStores->fetchAll(PDO::FETCH_ASSOC);
     <script>
         $(document).ready(function() {
             $('#storesTable').DataTable({
-                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json' },
+                language: { url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json' },
                 order: [[1, 'asc']]
             });
         });

--- a/manager_dashboard.php
+++ b/manager_dashboard.php
@@ -40,11 +40,11 @@ for ($i = 6; $i >= 0; $i--) {
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Painel do Gerente – Escala Hillbillys</title>
+    <title>Manager Dashboard – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -60,34 +60,34 @@ for ($i = 6; $i >= 0; $i--) {
         <div class="row mb-4">
             <div class="col-md-4">
                 <div class="card text-white bg-success mb-3">
-                    <div class="card-header">Funcionários</div>
+                    <div class="card-header">Employees</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $employeeCount; ?></h5>
-                        <p class="card-text">Número de funcionários nesta loja.</p>
+                        <p class="card-text">Number of employees in this store.</p>
                     </div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card text-white bg-info mb-3">
-                    <div class="card-header">Escalas Futuras</div>
+                    <div class="card-header">Upcoming Shifts</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $shiftsCount; ?></h5>
-                        <p class="card-text">Turnos futuros para esta loja.</p>
+                        <p class="card-text">Future shifts scheduled for this store.</p>
                     </div>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card text-white bg-warning mb-3">
-                    <div class="card-header">Horas no Mês</div>
+                    <div class="card-header">Hours This Month</div>
                     <div class="card-body">
                         <h5 class="card-title">Total: <?php echo $totalHours; ?> h</h5>
-                        <p class="card-text">Horas trabalhadas neste mês pelos funcionários da loja.</p>
+                        <p class="card-text">Hours worked this month by store employees.</p>
                     </div>
                 </div>
             </div>
         </div>
         <div class="card">
-            <div class="card-header">Horas trabalhadas (últimos 7 dias)</div>
+            <div class="card-header">Hours Worked (Last 7 Days)</div>
             <div class="card-body">
                 <canvas id="hoursChart"></canvas>
             </div>
@@ -99,8 +99,8 @@ for ($i = 6; $i >= 0; $i--) {
     const ctx = document.getElementById('hoursChart').getContext('2d');
     new Chart(ctx, {
         type: 'bar',
-        data: { labels: chartLabels, datasets: [{ label: 'Horas trabalhadas', data: chartData, backgroundColor: 'rgba(54,162,235,0.5)', borderColor: 'rgba(54,162,235,1)', borderWidth: 1 }] },
-        options: { scales: { y: { beginAtZero: true, title: { display: true, text: 'Horas' } }, x: { title: { display: true, text: 'Data' } } }, plugins: { legend: { display: false } } }
+        data: { labels: chartLabels, datasets: [{ label: 'Hours worked', data: chartData, backgroundColor: 'rgba(54,162,235,0.5)', borderColor: 'rgba(54,162,235,1)', borderWidth: 1 }] },
+        options: { scales: { y: { beginAtZero: true, title: { display: true, text: 'Hours' } }, x: { title: { display: true, text: 'Date' } } }, plugins: { legend: { display: false } } }
     });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/minhas_notificacoes.php
+++ b/minhas_notificacoes.php
@@ -1,1 +1,1 @@
-<!-- minha página de notificações: use a versão enviada anteriormente ou peça para eu recriar agora -->
+<!-- my notifications page: use the version sent earlier or ask me to recreate it now -->

--- a/navbar.php
+++ b/navbar.php
@@ -6,15 +6,15 @@
  * administrator and manager pages. To use it, each page should set
  * `$activePage` to one of the following values before including this file:
  *
- *   'usuarios'    => Funcionários
- *   'escalas'     => Escalas
- *   'calendario'  => Calendário
- *   'pontos'      => Pontos
- *   'relatorios'  => Relatórios
- *   'desempenho'  => Desempenho
- *   'metricas'    => Métricas (Analytics)
- *   'lojas'       => Lojas (admin)
- *   'loja'        => Loja (manager)
+ *   'usuarios'    => Employees
+ *   'escalas'     => Schedules
+ *   'calendario'  => Calendar
+ *   'pontos'      => Time Entries
+ *   'relatorios'  => Reports
+ *   'desempenho'  => Performance
+ *   'metricas'    => Analytics
+ *   'lojas'       => Stores (admin)
+ *   'loja'        => Store (manager)
  *
  * The file determines the current user's role (admin, manager, employee)
  * using the helper currentUser() from config.php if available. It falls
@@ -33,7 +33,7 @@ if (function_exists('currentUser')) {
 // Determine brand link based on role
 if ($role === 'manager') {
     $brandHref = 'manager_dashboard.php';
-    $brandText = 'Escala Hillbillys – Gerente';
+    $brandText = 'Escala Hillbillys – Manager';
 } elseif ($role === 'employee') {
     // Employees should not normally include this nav; but default to portal
     $brandHref = 'portal.php';
@@ -57,45 +57,45 @@ if (!function_exists('nav_active')) {
         <a class="navbar-brand" href="<?php echo htmlspecialchars($brandHref); ?>">
             <?php echo htmlspecialchars($brandText); ?>
         </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alternar navegação">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('usuarios', $activePage); ?>" href="usuarios_listar.php">Funcionários</a>
+                    <a class="nav-link <?php echo nav_active('usuarios', $activePage); ?>" href="usuarios_listar.php">Employees</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link <?php echo nav_active('escalas', $activePage); ?>" href="escala_listar.php">Escalas</a>
                 </li>
                 <li class="nav-item">
-                    <!-- O item "Calendário" agora aponta para a visualização semanal recém-criada -->
-                    <a class="nav-link <?php echo nav_active('calendario', $activePage); ?>" href="escala_calendario_semana.php">Calendário</a>
+                    <!-- The "Calendar" item now points to the weekly view -->
+                    <a class="nav-link <?php echo nav_active('calendario', $activePage); ?>" href="escala_calendario_semana.php">Calendar</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('pontos', $activePage); ?>" href="ponto_listar.php">Pontos</a>
+                    <a class="nav-link <?php echo nav_active('pontos', $activePage); ?>" href="ponto_listar.php">Time Entries</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('relatorios', $activePage); ?>" href="relatorios.php">Relatórios</a>
+                    <a class="nav-link <?php echo nav_active('relatorios', $activePage); ?>" href="relatorios.php">Reports</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('desempenho', $activePage); ?>" href="desempenho.php">Desempenho</a>
+                    <a class="nav-link <?php echo nav_active('desempenho', $activePage); ?>" href="desempenho.php">Performance</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('metricas', $activePage); ?>" href="analytics.php">Métricas</a>
+                    <a class="nav-link <?php echo nav_active('metricas', $activePage); ?>" href="analytics.php">Analytics</a>
                 </li>
                 <?php if ($role === 'admin'): ?>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('lojas', $activePage); ?>" href="lojas_listar.php">Lojas</a>
+                    <a class="nav-link <?php echo nav_active('lojas', $activePage); ?>" href="lojas_listar.php">Stores</a>
                 </li>
                 <?php elseif ($role === 'manager'): ?>
                 <li class="nav-item">
-                    <a class="nav-link <?php echo nav_active('loja', $activePage); ?>" href="loja_gerenciar_updated.php">Loja</a>
+                    <a class="nav-link <?php echo nav_active('loja', $activePage); ?>" href="loja_gerenciar_updated.php">Store</a>
                 </li>
                 <?php endif; ?>
             </ul>
             <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><a class="nav-link" href="logout.php">Sair</a></li>
+                <li class="nav-item"><a class="nav-link" href="logout.php">Sign Out</a></li>
             </ul>
         </div>
     </div>

--- a/notifications.php
+++ b/notifications.php
@@ -1,51 +1,51 @@
 <?php
-// notifications.php – página de listagem e leitura de notificações de usuário
-// Inclui o arquivo de configuração e verifica login
+// notifications.php – user notification listing and reading page
+// Includes configuration and verifies login
 require_once 'config.php';
 requireLogin();
 
 $userId = $_SESSION['user_id'];
 
-// Função local de fallback caso addNotification não esteja definida em config.php
+// Local fallback if addNotification is not defined in config.php
 if (!function_exists('addNotification')) {
     function addNotification($pdo, $userId, $message, $type = 'general', $sendEmail = false) {
         $stmt = $pdo->prepare('INSERT INTO notifications (user_id, message, type) VALUES (?, ?, ?)');
         $stmt->execute([$userId, $message, $type]);
-        // Email opcional
+        // Optional email
         if ($sendEmail) {
-            // Buscar email do usuário
+            // Fetch user email
             $userStmt = $pdo->prepare('SELECT email, name FROM users JOIN employees ON users.employee_id = employees.id WHERE users.id = ?');
             $userStmt->execute([$userId]);
             $user = $userStmt->fetch(PDO::FETCH_ASSOC);
             if ($user) {
                 $to      = $user['email'];
-                $subject = 'Notificação Escala Hillbillys';
-                $body    = "Olá {$user['name']},\n\n{$message}\n\nEquipe Escala Hillbillys";
-                // Utilize mail() se configurado ou biblioteca externa
+                $subject = 'Escala Hillbillys Notification';
+                $body    = "Hello {$user['name']},\n\n{$message}\n\nEscala Hillbillys Team";
+                // Use mail() if configured or an external library
                 @mail($to, $subject, $body);
             }
         }
     }
 }
 
-// Tratar marcação como lida
+// Handle marking notifications as read
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['notification_id'])) {
     $id = intval($_POST['notification_id']);
     $stmt = $pdo->prepare('UPDATE notifications SET status = "read" WHERE id = ? AND user_id = ?');
     $stmt->execute([$id, $userId]);
 }
 
-// Obter notificações do usuário
+// Fetch notifications for the user
 $stmt = $pdo->prepare('SELECT id, message, type, status, created_at FROM notifications WHERE user_id = ? ORDER BY created_at DESC');
 $stmt->execute([$userId]);
 $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Notificações – Escala Hillbillys</title>
+    <title>Notifications – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -56,9 +56,9 @@ $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Notificações</h3>
+        <h3>Notifications</h3>
         <?php if (empty($notifications)): ?>
-            <p>Você não possui notificações no momento.</p>
+            <p>You do not have notifications right now.</p>
         <?php else: ?>
             <div class="list-group">
                 <?php foreach ($notifications as $n): ?>
@@ -71,7 +71,7 @@ $notifications = $stmt->fetchAll(PDO::FETCH_ASSOC);
                         <?php if ($n['status'] === 'unread'): ?>
                             <form method="post" style="margin:0;">
                                 <input type="hidden" name="notification_id" value="<?php echo $n['id']; ?>">
-                                <button type="submit" class="btn btn-sm btn-outline-success">Marcar como lida</button>
+                                <button type="submit" class="btn btn-sm btn-outline-success">Mark as read</button>
                             </form>
                         <?php endif; ?>
                     </div>

--- a/notifications_api.php
+++ b/notifications_api.php
@@ -17,11 +17,11 @@ try{
     }
   } elseif($method==='POST'){
     if($action==='mark_read'){
-      $id=isset($_POST['id'])?(int)$_POST['id']:0; if($id<=0){ echo json_encode(['success'=>false,'message'=>'ID inválido.']); exit(); }
+      $id=isset($_POST['id'])?(int)$_POST['id']:0; if($id<=0){ echo json_encode(['success'=>false,'message'=>'Invalid ID.']); exit(); }
       $st=$pdo->prepare('UPDATE notifications SET status="read" WHERE id=? AND user_id=?'); $st->execute([$id,$userId]); echo json_encode(['success'=>true]); exit();
     } elseif($action==='mark_all_read'){
       $st=$pdo->prepare('UPDATE notifications SET status="read" WHERE user_id=? AND status="unread"'); $st->execute([$userId]); echo json_encode(['success'=>true]); exit();
     }
   }
-  echo json_encode(['success'=>false,'message'=>'Ação não suportada.']);
-}catch(Exception $e){ echo json_encode(['success'=>false,'message'=>'Erro: '.$e->getMessage()]); }
+  echo json_encode(['success'=>false,'message'=>'Unsupported action.']);
+}catch(Exception $e){ echo json_encode(['success'=>false,'message'=>'Error: '.$e->getMessage()]); }

--- a/notifications_helpers.php
+++ b/notifications_helpers.php
@@ -16,7 +16,7 @@ function addNotification(PDO $pdo, int $userId, string $message, string $type='g
     $stmt = $pdo->prepare('INSERT INTO notifications (user_id, message, type) VALUES (?, ?, ?)');
     $stmt->execute([$userId, $message, $type]);
 }
-function formatShiftMsg(string $date, string $start, string $end, ?string $storeName=null, string $action='Atribuído'): string {
-    $storePart = $storeName ? " na loja $storeName" : '';
-    return "$action: $date das $start às $end$storePart.";
+function formatShiftMsg(string $date, string $start, string $end, ?string $storeName=null, string $action='Assigned'): string {
+    $storePart = $storeName ? " at store $storeName" : '';
+    return "$action: $date from $start to $end$storePart.";
 }

--- a/notifications_widget.php
+++ b/notifications_widget.php
@@ -3,17 +3,17 @@ require_once 'config.php';
 requireLogin();
 ?>
 <li class="nav-item dropdown">
-  <a class="nav-link position-relative" href="#" id="notifDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Notificações">
+  <a class="nav-link position-relative" href="#" id="notifDropdown" data-bs-toggle="dropdown" aria-expanded="false" title="Notifications">
     <span style="font-size:1.25rem;">🔔</span>
     <span id="notifBadge" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="display:none;">0</span>
   </a>
   <div class="dropdown-menu dropdown-menu-end p-0 shadow" aria-labelledby="notifDropdown" style="min-width:320px;">
     <div class="list-group list-group-flush" id="notifList">
-      <div class="p-3 text-muted small">Carregando...</div>
+      <div class="p-3 text-muted small">Loading...</div>
     </div>
     <div class="d-flex justify-content-between p-2 border-top">
-      <button class="btn btn-sm btn-outline-secondary" id="notifRefreshBtn" type="button">Atualizar</button>
-      <button class="btn btn-sm btn-primary" id="notifMarkAllBtn" type="button">Marcar todas como lidas</button>
+      <button class="btn btn-sm btn-outline-secondary" id="notifRefreshBtn" type="button">Refresh</button>
+      <button class="btn btn-sm btn-primary" id="notifMarkAllBtn" type="button">Mark all as read</button>
     </div>
   </div>
 </li>
@@ -28,18 +28,18 @@ requireLogin();
     }catch(e){}
   }
   async function loadList(){
-    const listEl=document.getElementById('notifList'); listEl.innerHTML='<div class="p-3 text-muted small">Carregando...</div>';
+    const listEl=document.getElementById('notifList'); listEl.innerHTML='<div class="p-3 text-muted small">Loading...</div>';
     try{
       const data=await fetchJSON('notifications_api.php?action=list&limit=10');
-      if(!data.success){ listEl.innerHTML='<div class="p-3 text-danger small">Falha ao carregar.</div>'; return; }
-      if(!data.items||data.items.length===0){ listEl.innerHTML='<div class="p-3 text-muted small">Sem notificações.</div>'; return; }
+      if(!data.success){ listEl.innerHTML='<div class="p-3 text-danger small">Failed to load.</div>'; return; }
+      if(!data.items||data.items.length===0){ listEl.innerHTML='<div class="p-3 text-muted small">No notifications.</div>'; return; }
       listEl.innerHTML='';
       data.items.forEach(item=>{
         const a=document.createElement('a'); a.href='#'; a.className='list-group-item list-group-item-action d-flex justify-content-between align-items-start';
         a.innerHTML='<div class="me-2">'
           + '<div class="fw-semibold ' + (item.status==='unread'?'text-primary':'') + '">' + escapeHtml(item.message) + '</div>'
           + '<div class="small text-muted">' + escapeHtml(item.created_at) + '</div>'
-          + '</div>' + (item.status==='unread'?'<span class="badge bg-primary rounded-pill">novo</span>':'');
+          + '</div>' + (item.status==='unread'?'<span class="badge bg-primary rounded-pill">new</span>':'');
         a.addEventListener('click', async (ev)=>{
           ev.preventDefault();
           if(item.status==='unread'){
@@ -50,7 +50,7 @@ requireLogin();
         });
         listEl.appendChild(a);
       });
-    }catch(e){ listEl.innerHTML='<div class="p-3 text-danger small">Erro ao carregar.</div>'; }
+    }catch(e){ listEl.innerHTML='<div class="p-3 text-danger small">Error loading.</div>'; }
   }
   function escapeHtml(s){ return String(s).replace(/[&<>"']/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
   document.addEventListener('DOMContentLoaded',function(){

--- a/ponto_corrigir.php
+++ b/ponto_corrigir.php
@@ -1,19 +1,19 @@
 <?php
-// ponto_corrigir.php – permite a correção manual de registros de ponto pelos gerentes ou administradores.
-// O usuário pode ajustar os horários de entrada/saída e fornecer uma justificativa. As correções
-// são registradas com data, usuário que corrigiu e motivo.
+// ponto_corrigir.php – allow managers or administrators to manually adjust time entries.
+// Users can update clock-in/clock-out times and provide a justification. Corrections
+// are recorded with timestamp, user, and reason.
 
 require_once 'config.php';
 requirePrivileged();
 
-// Obter ID do registro de ponto a corrigir
+// Retrieve the time entry ID to correct
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($id <= 0) {
     header('Location: ponto_listar.php');
     exit();
 }
 
-// Buscar registro de ponto com nome do funcionário e loja
+// Fetch the time entry with employee name and store
 $stmt = $pdo->prepare('SELECT te.*, e.name AS employee_name, e.store_id FROM time_entries te JOIN employees e ON te.employee_id = e.id WHERE te.id = ?');
 $stmt->execute([$id]);
 $entry = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -22,7 +22,7 @@ if (!$entry) {
     exit();
 }
 
-// Verificar permissão do gerente: só pode corrigir pontos de funcionários de sua loja
+// Ensure managers only edit entries for employees in their store
 $role = $_SESSION['user_role'];
 if ($role === 'manager') {
     $currentUser = currentUser();
@@ -33,36 +33,36 @@ if ($role === 'manager') {
     }
 }
 
-// Processar atualização
+// Process updates
 $message = null;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $newClockIn  = $_POST['clock_in'] ?? '';
     $newClockOut = $_POST['clock_out'] ?? '';
     $reason      = trim($_POST['correction_reason'] ?? '');
-    // Converter os inputs datetime-local para formato Y-m-d H:i:s
+    // Convert datetime-local inputs to Y-m-d H:i:s
     $clockInFormatted  = $newClockIn ? date('Y-m-d H:i:s', strtotime($newClockIn)) : null;
     $clockOutFormatted = $newClockOut ? date('Y-m-d H:i:s', strtotime($newClockOut)) : null;
     $userId = $_SESSION['user_id'];
-    // Atualizar o registro
+    // Update the record
     $stmtUpd = $pdo->prepare('UPDATE time_entries SET clock_in = ?, clock_out = ?, correction_reason = ?, corrected_at = CURRENT_TIMESTAMP, corrected_by = ? WHERE id = ?');
     $stmtUpd->execute([$clockInFormatted, $clockOutFormatted, $reason, $userId, $id]);
-    $message = 'Registro atualizado com sucesso.';
+    $message = 'Time entry updated successfully.';
     // Atualizar a entrada para exibir valores corrigidos
     $stmt->execute([$id]);
     $entry = $stmt->fetch(PDO::FETCH_ASSOC);
 }
 
-// Preparar valores para o formulário
-// Para os campos datetime-local, é necessário usar o formato "Y-m-d\TH:i".
+// Prepare values for the form
+// datetime-local inputs must use the format "Y-m-d\TH:i".
 $valueClockIn = $entry['clock_in'] ? date('Y-m-d\TH:i', strtotime($entry['clock_in'])) : '';
 $valueClockOut = $entry['clock_out'] ? date('Y-m-d\TH:i', strtotime($entry['clock_out'])) : '';
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Corrigir Registro de Ponto – Escala Hillbillys</title>
+    <title>Correct Time Entry – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -72,34 +72,34 @@ $valueClockOut = $entry['clock_out'] ? date('Y-m-d\TH:i', strtotime($entry['cloc
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Corrigir Registro de Ponto</h3>
-        <p><strong>Funcionário:</strong> <?php echo htmlspecialchars($entry['employee_name']); ?></p>
+        <h3>Correct Time Entry</h3>
+        <p><strong>Employee:</strong> <?php echo htmlspecialchars($entry['employee_name']); ?></p>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
         <form method="post">
             <div class="row g-3 mb-3">
                 <div class="col-md-4">
-                    <label class="form-label">Entrada</label>
+                    <label class="form-label">Clock In</label>
                     <input type="datetime-local" class="form-control" name="clock_in" value="<?php echo htmlspecialchars($valueClockIn); ?>">
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label">Saída</label>
+                    <label class="form-label">Clock Out</label>
                     <input type="datetime-local" class="form-control" name="clock_out" value="<?php echo htmlspecialchars($valueClockOut); ?>">
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label">Motivo da Correção</label>
-                    <input type="text" class="form-control" name="correction_reason" placeholder="Justificativa" value="">
+                    <label class="form-label">Correction Reason</label>
+                    <input type="text" class="form-control" name="correction_reason" placeholder="Reason" value="">
                 </div>
             </div>
-            <button type="submit" class="btn btn-primary">Salvar Correção</button>
-            <a href="ponto_listar.php" class="btn btn-secondary ms-2">Voltar</a>
+            <button type="submit" class="btn btn-primary">Save Correction</button>
+            <a href="ponto_listar.php" class="btn btn-secondary ms-2">Back</a>
         </form>
         <?php if ($entry['correction_reason']): ?>
             <hr>
-            <h5>Correção Anterior</h5>
-            <p><strong>Justificativa:</strong> <?php echo htmlspecialchars($entry['correction_reason']); ?></p>
-            <p><strong>Corrigido em:</strong> <?php echo htmlspecialchars($entry['corrected_at']); ?></p>
+            <h5>Previous Correction</h5>
+            <p><strong>Reason:</strong> <?php echo htmlspecialchars($entry['correction_reason']); ?></p>
+            <p><strong>Corrected at:</strong> <?php echo htmlspecialchars($entry['corrected_at']); ?></p>
         <?php endif; ?>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/ponto_listar.php
+++ b/ponto_listar.php
@@ -24,11 +24,11 @@ if ($role === 'manager') {
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Registros de Ponto – Escala Hillbillys</title>
+    <title>Time Entries – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <!-- DataTables CSS for enhanced tables -->
@@ -41,22 +41,22 @@ if ($role === 'manager') {
     ?>
     <div class="container mt-4">
         <div class="d-flex justify-content-between align-items-center mb-3">
-            <h3>Registros de Ponto</h3>
-            <div class="btn-group" role="group" aria-label="Ações">
-                <a href="export_time_entries.php" class="btn btn-secondary">Exportar CSV</a>
-                <a href="ponto_registrar.php" class="btn btn-success">Registrar Ponto</a>
+            <h3>Time Entries</h3>
+            <div class="btn-group" role="group" aria-label="Actions">
+                <a href="export_time_entries.php" class="btn btn-secondary">Export CSV</a>
+                <a href="ponto_registrar.php" class="btn btn-success">Record Time Entry</a>
             </div>
         </div>
         <table id="timeEntriesTable" class="table table-striped">
             <thead>
                 <tr>
                     <th>ID</th>
-                    <th>Funcionário</th>
-                    <th>Entrada</th>
-                    <th>Saída</th>
-                    <th>Justificativa</th>
-                    <th>Duração (h)</th>
-                    <th>Ações</th>
+                    <th>Employee</th>
+                    <th>Clock In</th>
+                    <th>Clock Out</th>
+                    <th>Justification</th>
+                    <th>Duration (h)</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -78,7 +78,7 @@ if ($role === 'manager') {
                         <td><?php echo $duration; ?></td>
                         <td>
                             <?php if ($_SESSION['user_role'] !== 'employee'): ?>
-                                <a href="ponto_corrigir.php?id=<?php echo $entry['id']; ?>" class="btn btn-sm btn-warning">Corrigir</a>
+                                <a href="ponto_corrigir.php?id=<?php echo $entry['id']; ?>" class="btn btn-sm btn-warning">Adjust</a>
                             <?php endif; ?>
                         </td>
                     </tr>
@@ -94,7 +94,7 @@ if ($role === 'manager') {
     document.addEventListener('DOMContentLoaded', function() {
         $('#timeEntriesTable').DataTable({
             language: {
-                url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json'
+                url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json'
             },
             order: [[2, 'desc']]
         });

--- a/ponto_registrar.php
+++ b/ponto_registrar.php
@@ -1,5 +1,5 @@
 <?php
-// ponto_registrar.php – registro de ponto (clock in/out)
+// ponto_registrar.php – register time entries (clock in/out)
 require_once 'config.php';
 // Only managers and admins should register point on behalf of employees.
 // Employees use their portal to register their own point.
@@ -28,7 +28,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($emp['id'] == $employee_id) { $allowed = true; break; }
         }
         if (!$allowed) {
-            $message = 'Funcionário inválido para sua loja.';
+            $message = 'Employee not available for your store.';
         }
     }
     if (!isset($message)) {
@@ -42,22 +42,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $justification = trim($_POST['justification'] ?? '');
             $stmt = $pdo->prepare('UPDATE time_entries SET clock_out = ?, justification = ? WHERE id = ?');
             $stmt->execute([$now, $justification, $openEntry['id']]);
-            $message = 'Saída registrada com sucesso.';
+            $message = 'Clock-out recorded successfully.';
         } else {
             // User is clocking in
             $stmt = $pdo->prepare('INSERT INTO time_entries (employee_id, clock_in) VALUES (?, ?)');
             $stmt->execute([$employee_id, $now]);
-            $message = 'Entrada registrada com sucesso.';
+            $message = 'Clock-in recorded successfully.';
         }
     }
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Registrar Ponto – Escala Hillbillys</title>
+    <title>Record Time Entry – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -67,15 +67,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Registrar Ponto</h3>
+        <h3>Record Time Entry</h3>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
         <form method="post">
             <div class="mb-3">
-                <label class="form-label">Funcionário</label>
+                <label class="form-label">Employee</label>
                 <select class="form-select" name="employee_id" required>
-                    <option value="">Selecione...</option>
+                    <option value="">Select...</option>
                     <?php foreach ($employees as $emp): ?>
                         <option value="<?php echo $emp['id']; ?>">
                             <?php echo htmlspecialchars($emp['name']); ?>
@@ -84,11 +84,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </select>
             </div>
             <div class="mb-3">
-                <label class="form-label">Justificativa (opcional)</label>
-                <input type="text" class="form-control" name="justification" placeholder="Digite a justificativa caso esteja atrasado ou saindo mais cedo">
+                <label class="form-label">Justification (optional)</label>
+                <input type="text" class="form-control" name="justification" placeholder="Enter a reason if late or leaving early">
             </div>
-            <button type="submit" class="btn btn-success">Registrar</button>
-            <a href="ponto_listar.php" class="btn btn-secondary">Voltar</a>
+            <button type="submit" class="btn btn-success">Record</button>
+            <a href="ponto_listar.php" class="btn btn-secondary">Back</a>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/populate_employees.php
+++ b/populate_employees.php
@@ -1,9 +1,9 @@
 <?php
-// populate_employees.php – script para popular o banco com 30 funcionários fictícios
+// populate_employees.php – script to seed the database with 30 sample employees
 require_once 'config.php';
 requireAdmin();
 
-// Arrays de nomes para combinar aleatoriamente
+// Name arrays for random pairing
 $firstNames = ['Aidan','Bridget','Ciaran','Deirdre','Eoin','Fiona','Grainne','Hugh','Ian','Jillian',
     'Kevin','Laura','Maeve','Niall','Orla','Padraig','Roisin','Seamus','Tara','Una',
     'Vaughan','Siobhan','Cathal','Darragh','Elaine','Fergal','Grainne','Isolde','Liam','Muireann'];
@@ -11,14 +11,14 @@ $lastNames  = ['O\'Connor','Murphy','Kelly','O\'Brien','Smith','Doyle','Byrne','
     'Kennedy','Lynch','McCarthy','Maher','Nolan','Power','Quinn','Reid','Sweeney','Ward',
     'Gallagher','Doran','Keane','Flynn','Moran','Brady','Hayes','Kavanagh','Moore','Clarke'];
 
-// Obter lojas existentes ou criar uma padrão se necessário
+// Fetch existing stores or create a default one if necessary
 $storeIds = $pdo->query('SELECT id FROM stores')->fetchAll(PDO::FETCH_COLUMN);
 if (!$storeIds) {
-    $pdo->exec("INSERT INTO stores (name, location) VALUES ('Loja Padrão','Localização Padrão')");
+    $pdo->exec("INSERT INTO stores (name, location) VALUES ('Default Store','Default Location')");
     $storeIds = [$pdo->lastInsertId()];
 }
 
-// Preparar inserção
+// Prepare insert statement
 $insert = $pdo->prepare('INSERT INTO employees (name, phone, email, store_id, ppsn, irp, hourly_rate) VALUES (?, ?, ?, ?, ?, ?, ?)');
 for ($i = 0; $i < 30; $i++) {
     $first = $firstNames[array_rand($firstNames)];
@@ -33,4 +33,4 @@ for ($i = 0; $i < 30; $i++) {
     $insert->execute([$name, $phone, $email, $store, $ppsn, $irp, $rate]);
 }
 
-echo '30 funcionários fictícios foram adicionados.';
+echo '30 sample employees were added.';

--- a/portal.php
+++ b/portal.php
@@ -1,5 +1,5 @@
 <?php
-// portal.php – área do funcionário para visualizar escalas e pontos
+// portal.php – employee area to view shifts and time entries
 require_once 'config.php';
 requireLogin();
 
@@ -16,7 +16,7 @@ $stmt = $pdo->prepare('SELECT * FROM employees WHERE id = ?');
 $stmt->execute([$employeeId]);
 $employee = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$employee) {
-    die('Funcionário não encontrado.');
+    die('Employee not found.');
 }
 
 // Handle register point if button clicked
@@ -31,12 +31,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['register_point'])) {
         // Register clock out
         $stmt = $pdo->prepare('UPDATE time_entries SET clock_out = ? WHERE id = ?');
         $stmt->execute([$now, $openEntry['id']]);
-        $portalMessage = 'Saída registrada com sucesso.';
+        $portalMessage = 'Clock-out recorded successfully.';
     } else {
         // Register clock in
         $stmt = $pdo->prepare('INSERT INTO time_entries (employee_id, clock_in) VALUES (?, ?)');
         $stmt->execute([$employeeId, $now]);
-        $portalMessage = 'Entrada registrada com sucesso.';
+        $portalMessage = 'Clock-in recorded successfully.';
     }
 }
 
@@ -82,11 +82,11 @@ $hourlyRate = $employee['hourly_rate'] ?: 0;
 $earnings = $workedHours * $hourlyRate;
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Portal do Funcionário – Escala Hillbillys</title>
+    <title>Employee Portal – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -99,17 +99,17 @@ $earnings = $workedHours * $hourlyRate;
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="portal.php">Próximos Turnos</a></li>
-                    <li class="nav-item"><a class="nav-link" href="preferencias.php">Preferências</a></li>
+                    <li class="nav-item"><a class="nav-link" href="portal.php">Upcoming Shifts</a></li>
+                    <li class="nav-item"><a class="nav-link" href="preferencias.php">Preferences</a></li>
                 </ul>
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link" href="logout.php">Sair</a></li>
+                    <li class="nav-item"><a class="nav-link" href="logout.php">Sign Out</a></li>
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container mt-4">
-        <h3>Bem-vindo(a), <?php echo htmlspecialchars($employee['name']); ?></h3>
+        <h3>Welcome, <?php echo htmlspecialchars($employee['name']); ?></h3>
         <?php if ($portalMessage): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($portalMessage); ?></div>
         <?php endif; ?>
@@ -122,10 +122,10 @@ $earnings = $workedHours * $hourlyRate;
                 $stmt->execute([$employeeId]);
                 $openEntry = $stmt->fetch(PDO::FETCH_ASSOC);
                 if ($openEntry) {
-                    $buttonLabel = 'Registrar Saída';
+                    $buttonLabel = 'Clock Out';
                     $buttonClass = 'btn-danger';
                 } else {
-                    $buttonLabel = 'Registrar Entrada';
+                    $buttonLabel = 'Clock In';
                     $buttonClass = 'btn-success';
                 }
                 ?>
@@ -134,25 +134,25 @@ $earnings = $workedHours * $hourlyRate;
         </div>
         <!-- Summary of weekly hours and earnings -->
         <div class="mb-4">
-            <h5>Horas da Semana</h5>
-            <p>Horas agendadas: <strong><?php echo number_format($scheduledHours, 2); ?></strong>h</p>
-            <p>Horas trabalhadas: <strong><?php echo number_format($workedHours, 2); ?></strong>h</p>
+            <h5>Weekly Hours</h5>
+            <p>Scheduled hours: <strong><?php echo number_format($scheduledHours, 2); ?></strong>h</p>
+            <p>Worked hours: <strong><?php echo number_format($workedHours, 2); ?></strong>h</p>
             <?php $progress = ($scheduledHours > 0) ? min(100, ($workedHours / $scheduledHours) * 100) : 0; ?>
             <div class="progress" style="height: 20px;">
                 <div class="progress-bar" role="progressbar" style="width: <?php echo $progress; ?>%;" aria-valuenow="<?php echo $progress; ?>" aria-valuemin="0" aria-valuemax="100">
                     <?php echo number_format($progress, 0); ?>%
                 </div>
             </div>
-            <p class="mt-2">Horas restantes: <strong><?php echo number_format($remainingHours, 2); ?></strong>h</p>
-            <p>Ganhos estimados esta semana: <strong>€<?php echo number_format($earnings, 2); ?></strong></p>
+            <p class="mt-2">Remaining hours: <strong><?php echo number_format($remainingHours, 2); ?></strong>h</p>
+            <p>Estimated earnings this week: <strong>€<?php echo number_format($earnings, 2); ?></strong></p>
         </div>
-        <h4>Próximos Turnos</h4>
+        <h4>Upcoming Shifts</h4>
         <table class="table table-striped mb-4">
             <thead>
                 <tr>
-                    <th>Data</th>
-                    <th>Início</th>
-                    <th>Término</th>
+                    <th>Date</th>
+                    <th>Start</th>
+                    <th>End</th>
                 </tr>
             </thead>
             <tbody>
@@ -164,17 +164,17 @@ $earnings = $workedHours * $hourlyRate;
                     </tr>
                 <?php endforeach; ?>
                 <?php if (empty($upcomingShifts)): ?>
-                    <tr><td colspan="3">Nenhum turno futuro.</td></tr>
+                    <tr><td colspan="3">No upcoming shifts.</td></tr>
                 <?php endif; ?>
             </tbody>
         </table>
-        <h4>Últimos Registros de Ponto</h4>
+        <h4>Recent Time Entries</h4>
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th>Entrada</th>
-                    <th>Saída</th>
-                    <th>Duração (h)</th>
+                    <th>Clock In</th>
+                    <th>Clock Out</th>
+                    <th>Duration (h)</th>
                 </tr>
             </thead>
             <tbody>
@@ -194,7 +194,7 @@ $earnings = $workedHours * $hourlyRate;
                     </tr>
                 <?php endforeach; ?>
                 <?php if (empty($timeEntries)): ?>
-                    <tr><td colspan="3">Nenhum registro de ponto.</td></tr>
+                    <tr><td colspan="3">No time entries.</td></tr>
                 <?php endif; ?>
             </tbody>
         </table>

--- a/preferencias.php
+++ b/preferencias.php
@@ -1,11 +1,11 @@
 <?php
-// preferencias.php – página para os funcionários definirem suas preferências de disponibilidade de turnos.
-// Somente usuários com papel "employee" podem acessar esta página.
+// preferencias.php – page for employees to define their shift availability preferences.
+// Only users with the "employee" role may access this page.
 
 require_once 'config.php';
 requireLogin();
 
-// Garantir que apenas funcionários acessam
+// Ensure only employees access the page
 $currentUser = currentUser();
 if (!$currentUser || $currentUser['role'] !== 'employee') {
     header('Location: dashboard.php');
@@ -15,40 +15,40 @@ if (!$currentUser || $currentUser['role'] !== 'employee') {
 $employeeId = $currentUser['employee_id'];
 $message = null;
 
-// Processar envio do formulário
+// Process form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Para cada dia da semana (0=Domingo até 6=Sábado)
+    // For each day of the week (0=Sunday through 6=Saturday)
     for ($d = 0; $d < 7; $d++) {
         $start = $_POST['start'][$d] ?? '';
         $end   = $_POST['end'][$d] ?? '';
-        // Normalizar campos vazios para null
+        // Normalize empty fields to null
         $start = trim($start);
         $end = trim($end);
-        // Se ambos horários fornecidos
+        // If both times are provided
         if ($start !== '' && $end !== '') {
-            // Verificar se já existe uma preferência para este dia
+            // Check if a preference already exists for this day
             $stmtCheck = $pdo->prepare('SELECT id FROM employee_preferences WHERE employee_id = ? AND day_of_week = ?');
             $stmtCheck->execute([$employeeId, $d]);
             $prefId = $stmtCheck->fetchColumn();
             if ($prefId) {
-                // Atualizar existente
+                // Update existing record
                 $stmtUpd = $pdo->prepare('UPDATE employee_preferences SET available_start_time = ?, available_end_time = ? WHERE id = ?');
                 $stmtUpd->execute([$start, $end, $prefId]);
             } else {
-                // Inserir novo registro
+                // Insert new record
                 $stmtIns = $pdo->prepare('INSERT INTO employee_preferences (employee_id, day_of_week, available_start_time, available_end_time) VALUES (?, ?, ?, ?)');
                 $stmtIns->execute([$employeeId, $d, $start, $end]);
             }
         } else {
-            // Se não há horários, remover a preferência existente (se houver)
+            // If no times were provided, remove any existing preference
             $stmtDel = $pdo->prepare('DELETE FROM employee_preferences WHERE employee_id = ? AND day_of_week = ?');
             $stmtDel->execute([$employeeId, $d]);
         }
     }
-    $message = 'Preferências atualizadas com sucesso.';
+    $message = 'Preferences updated successfully.';
 }
 
-// Buscar preferências existentes para exibir no formulário
+// Fetch existing preferences to display in the form
 $stmtPrefs = $pdo->prepare('SELECT day_of_week, available_start_time, available_end_time FROM employee_preferences WHERE employee_id = ?');
 $stmtPrefs->execute([$employeeId]);
 $prefs = [];
@@ -56,15 +56,15 @@ foreach ($stmtPrefs->fetchAll(PDO::FETCH_ASSOC) as $row) {
     $prefs[$row['day_of_week']] = $row;
 }
 
-// Nomes dos dias da semana em português
-$dayNames = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
+// Day names for display
+$dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Preferências de Turno – Escala Hillbillys</title>
+    <title>Shift Preferences – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -72,33 +72,33 @@ $dayNames = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sába
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container-fluid">
             <a class="navbar-brand" href="portal.php">Escala Hillbillys</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Alternar navegação">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                    <li class="nav-item"><a class="nav-link" href="portal.php">Próximos Turnos</a></li>
-                    <li class="nav-item"><a class="nav-link active" aria-current="page" href="preferencias.php">Preferências</a></li>
+                    <li class="nav-item"><a class="nav-link" href="portal.php">Upcoming Shifts</a></li>
+                    <li class="nav-item"><a class="nav-link active" aria-current="page" href="preferencias.php">Preferences</a></li>
                 </ul>
                 <ul class="navbar-nav ms-auto">
-                    <li class="nav-item"><a class="nav-link" href="logout.php">Sair</a></li>
+                    <li class="nav-item"><a class="nav-link" href="logout.php">Sign Out</a></li>
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container mt-4">
-        <h3>Minhas Preferências de Turno</h3>
+        <h3>My Shift Preferences</h3>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
-        <p>Defina os horários nos quais você está disponível para trabalhar em cada dia da semana. Deixe em branco para indicar que não está disponível naquele dia.</p>
+        <p>Set the hours when you are available to work each day of the week. Leave fields blank to indicate you are unavailable on that day.</p>
         <form method="post">
             <table class="table table-striped">
                 <thead>
                     <tr>
-                        <th>Dia</th>
-                        <th>Início Disponível</th>
-                        <th>Fim Disponível</th>
+                        <th>Day</th>
+                        <th>Available Start</th>
+                        <th>Available End</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -116,8 +116,8 @@ $dayNames = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sába
                     <?php endfor; ?>
                 </tbody>
             </table>
-            <button type="submit" class="btn btn-primary">Salvar Preferências</button>
-            <a href="portal.php" class="btn btn-secondary ms-2">Voltar</a>
+            <button type="submit" class="btn btn-primary">Save Preferences</button>
+            <a href="portal.php" class="btn btn-secondary ms-2">Back</a>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/relatorios.php
+++ b/relatorios.php
@@ -1,5 +1,5 @@
 <?php
-// relatorios.php – relatórios e dashboards avançados
+// relatorios.php – advanced reports and dashboards
 require_once 'config.php';
 // Only allow managers and admins to view reports. Employees should not access this page.
 requirePrivileged();
@@ -45,11 +45,11 @@ foreach ($hoursPerEmployee as $row) {
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Relatórios – Escala Hillbillys</title>
+    <title>Reports – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
@@ -60,11 +60,11 @@ foreach ($hoursPerEmployee as $row) {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Relatórios e Dashboards</h3>
+        <h3>Reports and Dashboards</h3>
         <div class="row">
             <div class="col-lg-6">
                 <div class="card mb-4">
-                    <div class="card-header">Horas Trabalhadas por Funcionário (Mês Atual)</div>
+                    <div class="card-header">Hours Worked per Employee (Current Month)</div>
                     <div class="card-body">
                         <canvas id="employeeHoursChart"></canvas>
                     </div>
@@ -72,7 +72,7 @@ foreach ($hoursPerEmployee as $row) {
             </div>
             <div class="col-lg-6">
                 <div class="card mb-4">
-                    <div class="card-header">Horas Extras por Funcionário (Mês Atual)</div>
+                    <div class="card-header">Overtime per Employee (Current Month)</div>
                     <div class="card-body">
                         <canvas id="employeeOvertimeChart"></canvas>
                     </div>
@@ -91,7 +91,7 @@ foreach ($hoursPerEmployee as $row) {
         data: {
             labels: employeeLabels,
             datasets: [{
-                label: 'Horas Trabalhadas',
+                label: 'Hours Worked',
                 data: hoursData,
                 backgroundColor: 'rgba(75, 192, 192, 0.5)',
                 borderColor: 'rgba(75, 192, 192, 1)',
@@ -100,8 +100,8 @@ foreach ($hoursPerEmployee as $row) {
         },
         options: {
             scales: {
-                y: { beginAtZero: true, title: { display: true, text: 'Horas' } },
-                x: { title: { display: true, text: 'Funcionários' } }
+                y: { beginAtZero: true, title: { display: true, text: 'Hours' } },
+                x: { title: { display: true, text: 'Employees' } }
             },
             plugins: { legend: { display: false } }
         }
@@ -113,7 +113,7 @@ foreach ($hoursPerEmployee as $row) {
         data: {
             labels: employeeLabels,
             datasets: [{
-                label: 'Horas Extras',
+                label: 'Overtime Hours',
                 data: overtimeData,
                 backgroundColor: 'rgba(255, 99, 132, 0.5)',
                 borderColor: 'rgba(255, 99, 132, 1)',
@@ -122,8 +122,8 @@ foreach ($hoursPerEmployee as $row) {
         },
         options: {
             scales: {
-                y: { beginAtZero: true, title: { display: true, text: 'Horas' } },
-                x: { title: { display: true, text: 'Funcionários' } }
+                y: { beginAtZero: true, title: { display: true, text: 'Hours' } },
+                x: { title: { display: true, text: 'Employees' } }
             },
             plugins: { legend: { display: false } }
         }

--- a/schema_update_meta3.php
+++ b/schema_update_meta3.php
@@ -8,7 +8,7 @@ require_once 'config.php';
 
 // Only allow admins to run this script
 if (!isset($_SESSION['user_role']) || $_SESSION['user_role'] !== 'admin') {
-    die('Acesso negado. Apenas administradores podem executar a atualização do esquema.');
+    die('Access denied. Only administrators can run the schema update.');
 }
 
 try {
@@ -18,10 +18,10 @@ try {
     if (!in_array('max_weekly_hours', $columns)) {
         // Add max_weekly_hours column with default value 40 hours
         $pdo->exec("ALTER TABLE employees ADD COLUMN max_weekly_hours REAL DEFAULT 40.0");
-        echo 'Coluna max_weekly_hours adicionada com sucesso.';
+        echo 'Column max_weekly_hours added successfully.';
     } else {
-        echo 'A coluna max_weekly_hours já existe. Nenhuma alteração necessária.';
+        echo 'Column max_weekly_hours already exists. No changes needed.';
     }
 } catch (Exception $e) {
-    echo 'Erro ao atualizar o esquema: ' . $e->getMessage();
+    echo 'Error updating schema: ' . $e->getMessage();
 }

--- a/sidebar_notifications_badge.php
+++ b/sidebar_notifications_badge.php
@@ -1,1 +1,1 @@
-<!-- item do sidebar: use a versão enviada anteriormente ou peça para eu recriar agora -->
+<!-- sidebar item: use the version sent earlier or ask me to recreate it now -->

--- a/swap_action.php
+++ b/swap_action.php
@@ -1,5 +1,5 @@
 <?php
-// swap_action.php – aprovar ou rejeitar solicitações de troca de turno
+// swap_action.php – approve or reject shift swap requests
 require_once 'config.php';
 // Only allow managers and admins to approve/reject swap requests
 requirePrivileged();

--- a/swap_request.php
+++ b/swap_request.php
@@ -1,5 +1,5 @@
 <?php
-// swap_request.php – solicitar troca de turno
+// swap_request.php – request a shift swap
 require_once 'config.php';
 requireLogin();
 // Only employees should be able to request swaps
@@ -40,15 +40,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Insert swap request
     $stmt = $pdo->prepare('INSERT INTO swap_requests (shift_id, requested_by, requested_to, status) VALUES (?, ?, ?, "pending")');
     $stmt->execute([$shift_id, $requested_by, $requested_to]);
-    $message = 'Solicitação de troca registrada com sucesso.';
+    $message = 'Swap request recorded successfully.';
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Solicitar Troca – Escala Hillbillys</title>
+    <title>Request Swap – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -58,16 +58,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Solicitar Troca de Turno</h3>
+        <h3>Request Shift Swap</h3>
         <?php if ($message): ?>
             <div class="alert alert-success"><?php echo htmlspecialchars($message); ?></div>
         <?php endif; ?>
-        <p>Turno atual: <?php echo htmlspecialchars($shift['date'] . ' ' . $shift['start_time'] . '–' . $shift['end_time']); ?></p>
+        <p>Current shift: <?php echo htmlspecialchars($shift['date'] . ' ' . $shift['start_time'] . '–' . $shift['end_time']); ?></p>
         <form method="post">
             <div class="mb-3">
-                <label class="form-label">Selecionar funcionário para troca</label>
+                <label class="form-label">Select employee to swap with</label>
                 <select class="form-select" name="requested_to" required>
-                    <option value="">Selecione...</option>
+                    <option value="">Select...</option>
                     <?php foreach ($employees as $emp): ?>
                         <?php if ($emp['id'] != $shift['employee_id']): ?>
                             <option value="<?php echo $emp['id']; ?>">
@@ -77,8 +77,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <?php endforeach; ?>
                 </select>
             </div>
-            <button type="submit" class="btn btn-primary">Solicitar Troca</button>
-            <a href="escala_listar.php" class="btn btn-secondary">Cancelar</a>
+            <button type="submit" class="btn btn-primary">Request Swap</button>
+            <a href="escala_listar.php" class="btn btn-secondary">Cancel</a>
         </form>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/update_shift.php
+++ b/update_shift.php
@@ -1,7 +1,7 @@
 <?php
 // update_shift_restricted.php
-// Script para atualizar turnos com validações adicionais de datas passadas e escopo por loja.
-// Requer helpers: assertNotPastDate, userCanManageStore, getEmployeeStoreId.
+// Script to update shifts with additional validation for past dates and store-level scope.
+// Requires helpers: assertNotPastDate, userCanManageStore, getEmployeeStoreId.
 
 require_once __DIR__ . '/config.php';
 @require_once 'notifications_helpers.php';
@@ -20,42 +20,42 @@ $startTime = trim($_POST['start_time'] ?? '');
 $endTime   = trim($_POST['end_time'] ?? '');
 
 if (!$id) {
-    echo json_encode(['success' => false, 'message' => 'ID do turno ausente.']);
+    echo json_encode(['success' => false, 'message' => 'Shift ID missing.']);
     exit();
 }
 
 try {
-    // Carregar turno atual
+    // Load the current shift
     $q = $pdo->prepare('SELECT s.*, e.store_id AS emp_store, e.id AS employee_id, e.max_weekly_hours, e.name AS emp_name, st.name AS store_name FROM shifts s JOIN employees e ON e.id = s.employee_id LEFT JOIN stores st ON st.id = e.store_id WHERE s.id = ?');
     $q->execute([$id]);
     $current = $q->fetch(PDO::FETCH_ASSOC);
     if (!$current) {
-        echo json_encode(['success' => false, 'message' => 'Turno não encontrado.']);
+        echo json_encode(['success' => false, 'message' => 'Shift not found.']);
         exit();
     }
-    // Se gerente, verificar se pode manipular esta loja
+    // If a manager, verify they can manage this store
     if (!userCanManageStore((int)$current['emp_store'])) {
-        echo json_encode(['success' => false, 'message' => 'Sem permissão para alterar este turno.']);
+        echo json_encode(['success' => false, 'message' => 'You do not have permission to modify this shift.']);
         exit();
     }
-    // Determinar novos valores (fallback no atual se em branco)
+    // Determine new values (fall back to the current ones if blank)
     $newEmployee = $employee ?: (int)$current['employee_id'];
     $newDate     = $date ?: $current['date'];
     $newStart    = $startTime ?: $current['start_time'];
     $newEnd      = $endTime ?: $current['end_time'];
-    // Bloquear datas passadas
+    // Block past dates
     assertNotPastDate($newDate);
-    // Se mudou de funcionário, validar novo funcionário e permissão
+    // If the employee changed, validate the new employee and permissions
     if ($employee) {
         $emp = $pdo->prepare('SELECT id, store_id, max_weekly_hours, name FROM employees WHERE id = ?');
         $emp->execute([$newEmployee]);
         $empData = $emp->fetch(PDO::FETCH_ASSOC);
         if (!$empData) {
-            echo json_encode(['success' => false, 'message' => 'Funcionário inválido.']);
+            echo json_encode(['success' => false, 'message' => 'Invalid employee.']);
             exit();
         }
         if (!userCanManageStore((int)$empData['store_id'])) {
-            echo json_encode(['success' => false, 'message' => 'Sem permissão para atribuir este funcionário.']);
+            echo json_encode(['success' => false, 'message' => 'You do not have permission to assign this employee.']);
             exit();
         }
     } else {
@@ -67,24 +67,24 @@ try {
             'store_name' => $current['store_name']
         ];
     }
-    // Verificar duplicidade na mesma data para o novo funcionário
+    // Check for duplicate shifts on the same date for the new employee
     $dup = $pdo->prepare('SELECT COUNT(*) FROM shifts WHERE employee_id = ? AND date = ? AND id <> ?');
     $dup->execute([$newEmployee, $newDate, $id]);
     if ($dup->fetchColumn() > 0) {
-        echo json_encode(['success' => false, 'message' => 'Já existe um turno deste funcionário nesta data.']);
+        echo json_encode(['success' => false, 'message' => 'A shift for this employee already exists on this date.']);
         exit();
     }
-    // Verificar preferências de disponibilidade
+    // Check availability preferences
     $dow = date('w', strtotime($newDate));
     $prefStmt = $pdo->prepare('SELECT available_start_time, available_end_time FROM employee_preferences WHERE employee_id = ? AND day_of_week = ?');
     $prefStmt->execute([$newEmployee, $dow]);
     if ($p = $prefStmt->fetch(PDO::FETCH_ASSOC)) {
         if (strcmp($newStart, $p['available_start_time']) < 0 || strcmp($newEnd, $p['available_end_time']) > 0) {
-            echo json_encode(['success' => false, 'message' => 'Novo horário está fora da preferência do funcionário.']);
+            echo json_encode(['success' => false, 'message' => 'The new time is outside this employee’s preference window.']);
             exit();
         }
     }
-    // Verificar limite de horas semanais se existir
+    // Check the weekly hour limit if it exists
     $maxWeekly = $empData['max_weekly_hours'] ?? null;
     if ($maxWeekly) {
         $newDuration = (strtotime($newDate.' '.$newEnd) - strtotime($newDate.' '.$newStart)) / 3600.0;
@@ -98,20 +98,20 @@ try {
             $hoursSum += max(0, (strtotime($s['date'].' '.$s['end_time']) - strtotime($s['date'].' '.$s['start_time'])) / 3600.0);
         }
         if ($hoursSum + $newDuration > (float)$maxWeekly) {
-            echo json_encode(['success' => false, 'message' => 'Atualização excede o limite de horas semanais deste funcionário ('.$maxWeekly.'h).']);
+            echo json_encode(['success' => false, 'message' => 'Update exceeds this employee’s weekly hour limit ('.$maxWeekly.'h).']);
             exit();
         }
     }
-    // Atualizar turno
+    // Update the shift
     $up = $pdo->prepare('UPDATE shifts SET employee_id = ?, date = ?, start_time = ?, end_time = ? WHERE id = ?');
     $up->execute([$newEmployee, $newDate, $newStart, $newEnd, $id]);
-    // Notificação
+    // Notification
     if (function_exists('addNotification')) {
         $storeName = $empData['store_name'] ?? $current['store_name'] ?? null;
-        $msg = formatShiftMsg($newDate, $newStart, $newEnd, $storeName, 'Turno atualizado');
+        $msg = formatShiftMsg($newDate, $newStart, $newEnd, $storeName, 'Shift updated');
         addNotification($pdo, (int)$newEmployee, $msg, 'shift_updated');
     }
     echo json_encode(['success' => true]);
 } catch (Exception $e) {
-    echo json_encode(['success' => false, 'message' => 'Erro: '.$e->getMessage()]);
+    echo json_encode(['success' => false, 'message' => 'Error: '.$e->getMessage()]);
 }

--- a/usuario_criar.php
+++ b/usuario_criar.php
@@ -1,21 +1,20 @@
 <?php
 // usuario_criar_max.php
-// Este arquivo é uma versão extendida de usuario_criar.php com suporte para
-// definir o limite semanal de horas (max_weekly_hours) para cada funcionário.
+// Extended version of usuario_criar.php that supports defining the weekly hour limit (max_weekly_hours) for each employee.
 
 require_once 'config.php';
 
-// Somente usuários com privilégios podem acessar (admin ou gerente)
+// Only privileged users (admin or manager) may access
 requirePrivileged();
 
-// Verificar a loja do usuário para determinar as opções de lojas a serem exibidas
+// Determine store options based on the current user
 $stores = [];
 $currentUser = currentUser();
 if ($_SESSION['user_role'] === 'admin') {
-    // Administradores podem escolher qualquer loja
+    // Administrators may choose any store
     $stores = $pdo->query('SELECT * FROM stores ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 } else {
-    // Gerentes só podem associar funcionários à sua própria loja
+    // Managers can only associate employees with their own store
     if ($currentUser && $currentUser['store_id']) {
         $stmt = $pdo->prepare('SELECT * FROM stores WHERE id = ?');
         $stmt->execute([$currentUser['store_id']]);
@@ -23,7 +22,7 @@ if ($_SESSION['user_role'] === 'admin') {
     }
 }
 
-// Valores padrão do formulário
+// Default form values
 $defaultValues = [
     'name' => '',
     'email' => '',
@@ -39,7 +38,7 @@ $defaultValues = [
     'user_role' => 'employee'
 ];
 
-// Mesclar valores enviados via POST
+// Merge values submitted via POST
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     foreach ($defaultValues as $key => $val) {
         $defaultValues[$key] = $_POST[$key] ?? '';
@@ -58,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $ppsn = trim($_POST['ppsn'] ?? '');
     $irp = trim($_POST['irp'] ?? '');
     $hourly_rate = trim($_POST['hourly_rate'] ?? '');
-    // Novo campo de limite de horas semanais
+    // Weekly hour limit field
     $max_weekly_hours = trim($_POST['max_weekly_hours'] ?? '40');
     $selectedRole = 'employee';
     if ($createLogin) {
@@ -71,30 +70,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     if ($name === '') {
-        $errors[] = 'Nome é obrigatório.';
+        $errors[] = 'Name is required.';
     }
     if ($createLogin) {
         if ($username === '' || $password === '') {
-            $errors[] = 'Usuário e senha são obrigatórios para criar conta.';
+            $errors[] = 'Username and password are required to create an account.';
         }
         $check = $pdo->prepare('SELECT id FROM users WHERE username = ?');
         $check->execute([$username]);
         if ($check->fetch()) {
-            $errors[] = 'Nome de usuário já existente.';
+            $errors[] = 'Username already exists.';
         }
     }
     if (empty($errors)) {
-        // Determinar loja
+        // Determine store
         if ($store_id === '' && $_SESSION['user_role'] !== 'admin') {
             $store_id = $currentUser['store_id'] ?? null;
         }
-        // Inserir funcionário
+        // Insert employee
         $stmt = $pdo->prepare('INSERT INTO employees (name, email, phone, store_id, ppsn, irp, hourly_rate, max_weekly_hours) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
         $hourlyRateVal = ($hourly_rate !== '') ? floatval($hourly_rate) : null;
         $maxWeeklyVal = ($max_weekly_hours !== '') ? floatval($max_weekly_hours) : 40.0;
         $stmt->execute([$name, $email, $phone, $store_id ?: null, $ppsn ?: null, $irp ?: null, $hourlyRateVal, $maxWeeklyVal]);
         $employeeId = $pdo->lastInsertId();
-        // Criar login (opcional)
+        // Create login (optional)
         if ($createLogin) {
             $hash = password_hash($password, PASSWORD_DEFAULT);
             if ($selectedRole === 'manager') {
@@ -112,11 +111,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Novo Funcionário – Escala Hillbillys</title>
+    <title>New Employee – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -126,7 +125,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/navbar.php';
     ?>
     <div class="container mt-4">
-        <h3>Novo Funcionário</h3>
+        <h3>New Employee</h3>
         <?php if (!empty($errors)): ?>
             <div class="alert alert-danger">
                 <ul class="mb-0">
@@ -139,15 +138,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <form method="post">
             <div class="row g-3">
                 <div class="col-md-6">
-                    <label class="form-label">Nome</label>
+                    <label class="form-label">Name</label>
                     <input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($defaultValues['name']); ?>" required>
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label">E-mail</label>
+                    <label class="form-label">Email</label>
                     <input type="email" name="email" class="form-control" value="<?php echo htmlspecialchars($defaultValues['email']); ?>">
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label">Telefone</label>
+                    <label class="form-label">Phone</label>
                     <input type="text" name="phone" class="form-control" value="<?php echo htmlspecialchars($defaultValues['phone']); ?>">
                 </div>
                 <div class="col-md-6">
@@ -159,17 +158,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <input type="text" name="irp" class="form-control" value="<?php echo htmlspecialchars($defaultValues['irp']); ?>">
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label">Salário por Hora (€)</label>
+                    <label class="form-label">Hourly Pay (€)</label>
                     <input type="number" step="0.01" name="hourly_rate" class="form-control" value="<?php echo htmlspecialchars($defaultValues['hourly_rate']); ?>">
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label">Limite de Horas Semanais</label>
+                    <label class="form-label">Weekly Hour Limit</label>
                     <input type="number" step="0.1" name="max_weekly_hours" class="form-control" value="<?php echo htmlspecialchars($defaultValues['max_weekly_hours']); ?>">
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label">Loja</label>
+                    <label class="form-label">Store</label>
                     <select name="store_id" class="form-select">
-                        <option value="">Selecione...</option>
+                        <option value="">Select...</option>
                         <?php foreach ($stores as $s): ?>
                             <option value="<?php echo $s['id']; ?>" <?php echo ($defaultValues['store_id'] == $s['id']) ? 'selected' : ''; ?>><?php echo htmlspecialchars($s['name']); ?></option>
                         <?php endforeach; ?>
@@ -179,30 +178,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <hr>
             <div class="form-check mt-2">
                 <input type="checkbox" class="form-check-input" id="create_login" name="create_login" <?php echo ($defaultValues['create_login']) ? 'checked' : ''; ?>>
-                <label class="form-check-label" for="create_login">Criar conta de acesso para este funcionário</label>
+                <label class="form-check-label" for="create_login">Create a login account for this employee</label>
             </div>
             <div id="loginFields" style="display: <?php echo ($defaultValues['create_login']) ? 'block' : 'none'; ?>;">
                 <div class="row g-3 mt-2">
                     <div class="col-md-4">
-                        <label class="form-label">Usuário</label>
+                        <label class="form-label">Username</label>
                         <input type="text" name="username" class="form-control" value="<?php echo htmlspecialchars($defaultValues['username']); ?>">
                     </div>
                     <div class="col-md-4">
-                        <label class="form-label">Senha</label>
+                        <label class="form-label">Password</label>
                         <input type="password" name="password" class="form-control" value="">
                     </div>
                     <div class="col-md-4">
-                        <label class="form-label">Perfil de Acesso</label>
+                        <label class="form-label">Access Role</label>
                         <select name="user_role" class="form-select">
-                            <option value="employee" <?php echo ($defaultValues['user_role'] === 'employee') ? 'selected' : ''; ?>>Funcionário</option>
-                            <option value="manager" <?php echo ($defaultValues['user_role'] === 'manager') ? 'selected' : ''; ?>>Gerente</option>
+                            <option value="employee" <?php echo ($defaultValues['user_role'] === 'employee') ? 'selected' : ''; ?>>Employee</option>
+                            <option value="manager" <?php echo ($defaultValues['user_role'] === 'manager') ? 'selected' : ''; ?>>Manager</option>
                         </select>
                     </div>
                 </div>
             </div>
             <div class="mt-4">
-                <button type="submit" class="btn btn-success">Salvar</button>
-                <a href="usuarios_listar.php" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-success">Save</button>
+                <a href="usuarios_listar.php" class="btn btn-secondary">Cancel</a>
             </div>
         </form>
     </div>

--- a/usuario_excluir.php
+++ b/usuario_excluir.php
@@ -1,5 +1,5 @@
 <?php
-// usuario_excluir.php – excluir um funcionário
+// usuario_excluir.php – delete an employee
 require_once 'config.php';
 // Only admins and managers can delete employees
 requirePrivileged();

--- a/usuarios_listar.php
+++ b/usuarios_listar.php
@@ -1,5 +1,5 @@
 <?php
-// usuarios_listar.php – listagem de funcionários
+// usuarios_listar.php – employee listing
 require_once __DIR__ . '/config.php';
 requirePrivileged();
 
@@ -22,11 +22,11 @@ if ($_SESSION['user_role'] === 'manager') {
 }
 ?>
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Funcionários – Escala Hillbillys</title>
+    <title>Employees – Escala Hillbillys</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
     <!-- DataTables CSS for enhanced tables -->
@@ -40,25 +40,25 @@ if ($_SESSION['user_role'] === 'manager') {
 
     <div class="container mt-4">
         <div class="d-flex justify-content-between align-items-center mb-3">
-            <h3>Funcionários</h3>
+            <h3>Employees</h3>
             <div>
-                <a href="export_employees.php" class="btn btn-secondary me-2">Exportar CSV</a>
-                <a href="usuario_criar.php" class="btn btn-success">Adicionar Funcionário</a>
+                <a href="export_employees.php" class="btn btn-secondary me-2">Export CSV</a>
+                <a href="usuario_criar.php" class="btn btn-success">Add Employee</a>
             </div>
         </div>
         <table id="employeesTable" class="table table-striped">
             <thead>
                 <tr>
                     <th>ID</th>
-                    <th>Nome</th>
-                    <th>E-mail</th>
-                    <th>Telefone</th>
-                    <th>Loja</th>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Phone</th>
+                    <th>Store</th>
                     <th>PPSN</th>
                     <th>IRP</th>
-                    <th>Salário/h (€)</th>
-                    <th>Perfil</th>
-                    <th>Ações</th>
+                    <th>Pay/h (€)</th>
+                    <th>Role</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -75,15 +75,15 @@ if ($_SESSION['user_role'] === 'manager') {
                         <td>
                             <?php
                                 if (isset($emp['user_role'])) {
-                                    echo htmlspecialchars($emp['user_role'] === 'manager' ? 'Gerente' : 'Funcionário');
+                                    echo htmlspecialchars($emp['user_role'] === 'manager' ? 'Manager' : 'Employee');
                                 } else {
                                     echo '';
                                 }
                             ?>
                         </td>
                         <td>
-                            <a href="usuario_editar.php?id=<?php echo $emp['id']; ?>" class="btn btn-sm btn-primary">Editar</a>
-                            <a href="usuario_excluir.php?id=<?php echo $emp['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Tem certeza que deseja excluir este funcionário?');">Excluir</a>
+                            <a href="usuario_editar.php?id=<?php echo $emp['id']; ?>" class="btn btn-sm btn-primary">Edit</a>
+                            <a href="usuario_excluir.php?id=<?php echo $emp['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure you want to delete this employee?');">Delete</a>
                         </td>
                     </tr>
                 <?php endforeach; ?>
@@ -99,7 +99,7 @@ if ($_SESSION['user_role'] === 'manager') {
     document.addEventListener('DOMContentLoaded', function() {
         $('#employeesTable').DataTable({
             language: {
-                url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-BR.json'
+                url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/en-GB.json'
             },
             order: [[1, 'asc']]
         });

--- a/weekly_overview.php
+++ b/weekly_overview.php
@@ -1,10 +1,10 @@
 <?php
 // weekly_overview.php
-// Exibe um resumo semanal de horas agendadas, horas trabalhadas, horas restantes e ganhos estimados para o funcionário logado.
+// Display a weekly summary of scheduled hours, worked hours, remaining hours, and estimated earnings for the logged-in employee.
 
 require_once 'config.php';
 
-// Verifica login e restringe acesso apenas a funcionários
+// Ensure only employees can access
 requireLogin();
 requireEmployee();
 
@@ -14,17 +14,17 @@ $hourlyRate   = $user['hourly_rate'] ?? 0;
 $maxWeekly    = $user['max_weekly_hours'] ?? 40;
 
 if (!$employeeId) {
-    echo "Funcionário não associado ao usuário.";
+    echo "Employee not associated with the user.";
     exit();
 }
 
-// Determina o início (segunda-feira) e o fim (domingo) da semana atual.
+// Determine the start (Monday) and end (Sunday) of the current week.
 $monday = new DateTime('monday this week');
 $sunday = new DateTime('sunday this week');
 $dateStart = $monday->format('Y-m-d');
 $dateEnd   = $sunday->format('Y-m-d');
 
-// Calcula horas agendadas (shifts) em segundos
+// Calculate scheduled hours (shifts) in seconds
 $stmtShifts = $pdo->prepare(
     "SELECT COALESCE(SUM((strftime('%s', end_time) - strftime('%s', start_time))), 0) AS seconds " .
     "FROM shifts WHERE employee_id = ? AND date BETWEEN ? AND ?"
@@ -33,7 +33,7 @@ $stmtShifts->execute([$employeeId, $dateStart, $dateEnd]);
 $scheduledSeconds = (float)$stmtShifts->fetchColumn();
 $scheduledHours   = $scheduledSeconds / 3600.0;
 
-// Calcula horas trabalhadas (time entries) em segundos
+// Calculate worked hours (time entries) in seconds
 $stmtEntries = $pdo->prepare(
     "SELECT COALESCE(SUM((strftime('%s', COALESCE(clock_out, CURRENT_TIMESTAMP)) - strftime('%s', clock_in))), 0) AS seconds " .
     "FROM time_entries WHERE employee_id = ? AND DATE(clock_in) BETWEEN ? AND ?"
@@ -45,38 +45,37 @@ $workedHours     = $workedSeconds / 3600.0;
 $remainingHours  = max(0.0, $maxWeekly - $workedHours);
 $earnings        = $workedHours * $hourlyRate;
 
-// Formata números com 2 casas decimais (padrão europeu utiliza vírgula como separador decimal)
 function formatHours($hours) {
-    return number_format($hours, 2, ',', '.');
+    return number_format($hours, 2, '.', ',');
 }
 
 function formatCurrency($value) {
-    return number_format($value, 2, ',', '.');
+    return number_format($value, 2, '.', ',');
 }
 
 ?><!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Resumo Semanal – Escala Hillbillys</title>
+    <title>Weekly Summary – Escala Hillbillys</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <?php
-    // Inclui o menu de navegação padrão, se existir (você pode ajustar o nome do arquivo conforme seu projeto).
+    // Include standard navigation if present (adjust file name for your project).
     if (file_exists('menu.php')) {
         include 'menu.php';
     }
     ?>
     <div class="container mt-4">
-        <h1 class="mb-3">Meu Resumo Semanal</h1>
+        <h1 class="mb-3">My Weekly Summary</h1>
         <div class="row g-3">
             <div class="col-md-3">
                 <div class="card text-bg-primary">
                     <div class="card-body">
-                        <h5 class="card-title">Horas Agendadas</h5>
+                        <h5 class="card-title">Scheduled Hours</h5>
                         <p class="card-text fs-3"><?php echo formatHours($scheduledHours); ?> h</p>
                     </div>
                 </div>
@@ -84,7 +83,7 @@ function formatCurrency($value) {
             <div class="col-md-3">
                 <div class="card text-bg-success">
                     <div class="card-body">
-                        <h5 class="card-title">Horas Trabalhadas</h5>
+                        <h5 class="card-title">Worked Hours</h5>
                         <p class="card-text fs-3"><?php echo formatHours($workedHours); ?> h</p>
                     </div>
                 </div>
@@ -92,7 +91,7 @@ function formatCurrency($value) {
             <div class="col-md-3">
                 <div class="card text-bg-warning">
                     <div class="card-body">
-                        <h5 class="card-title">Horas Restantes</h5>
+                        <h5 class="card-title">Remaining Hours</h5>
                         <p class="card-text fs-3"><?php echo formatHours($remainingHours); ?> h</p>
                     </div>
                 </div>
@@ -100,14 +99,14 @@ function formatCurrency($value) {
             <div class="col-md-3">
                 <div class="card text-bg-info">
                     <div class="card-body">
-                        <h5 class="card-title">Ganhos Estimados</h5>
+                        <h5 class="card-title">Estimated Earnings</h5>
                         <p class="card-text fs-3">€ <?php echo formatCurrency($earnings); ?></p>
                     </div>
                 </div>
             </div>
         </div>
         <div class="mt-4">
-            <h4>Progresso da Semana</h4>
+            <h4>Week Progress</h4>
             <div class="progress" style="height: 30px;">
                 <?php
                 $percentage = $maxWeekly > 0 ? min(100, ($workedHours / $maxWeekly) * 100.0) : 0;


### PR DESCRIPTION
## Summary
- Translate remaining employee-facing UI text to English across dashboards, preference forms, and seed scripts.
- Update notifications, shift management flows, and login responses to emit English messages.
- Localize CSV export headers and configuration comments so generated reports and errors use English.

## Testing
- find . -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d03b2e33448332af12b6bb0c32cee2