### PR TITLE
Fix notifications API session user lookup

### DIFF
--- a/notifications_api.php
+++ b/notifications_api.php
@@ -3,7 +3,15 @@ require_once 'config.php';
 require_once 'notifications_helpers.php';
 requireLogin();
 header('Content-Type: application/json');
-$userId=(int)$_SESSION['user_id']; ensureNotificationsTable($pdo);
+
+$userId=isset($_SESSION['user']['id'])?(int)$_SESSION['user']['id']:0;
+if($userId<=0){
+  http_response_code(403);
+  echo json_encode(['success'=>false,'message'=>'Access denied.']);
+  exit();
+}
+
+ensureNotificationsTable($pdo);
 $method=$_SERVER['REQUEST_METHOD']; $action=$_GET['action'] ?? $_POST['action'] ?? 'count';
 try{
   if($method==='GET'){


### PR DESCRIPTION
## Summary
- switch the notifications API to read the logged-in user ID from the nested session structure
- block access when the user ID cannot be resolved and initialize the notifications table after validation

## Testing
- php -r 'session_id("cli"); session_start(); $_SESSION["user"]= ["id"=>1]; $_SERVER["REQUEST_METHOD"]="GET"; $_GET=["action"=>"count"]; include "notifications_api.php";'
- php -r 'session_id("cli"); session_start(); $_SESSION["user"]= ["id"=>1]; $_SERVER["REQUEST_METHOD"]="POST"; $_POST=["action"=>"mark_read","id"=>1]; include "notifications_api.php";'

------
https://chatgpt.com/codex/tasks/task_e_68d6cd33fc308332a8bec4cedbda1731